### PR TITLE
exploration of the (negative) relation between the fe/conductivity ratio and the electroneutrality

### DIFF
--- a/src/miscellaneous/electroneutrality_interaction_fe.Rmd
+++ b/src/miscellaneous/electroneutrality_interaction_fe.Rmd
@@ -43,8 +43,6 @@ chem.all <- get_chem(tubes_watina,watina,"1/1/1900", conc_type = "eq", collect =
 
 Overzicht van de chemische variabelen
 ```{r chemische variabelen, eval=TRUE, include=TRUE}
-#om een voor mij onbekende reden werkt deze code niet in Markdown, wel in een gewoon R-script.
-
 chem_var <- chem.all %>%
     select(chem_variable) %>%
     distinct %>%
@@ -63,7 +61,7 @@ De functie get_chem resulteert in een lange tabel-versie van alle chemische data
 Uit deze tabel filteren we de Fe- en de conductiviteitsmetingen (in het labo uitgevoerd). Deze data worden geïmporteerd en omgezet naar een brede  ('tidy')tabel.
 
 ```{r filter fe cond, eval=TRUE, include=TRUE}
-#om een voor mij onbekende reden werkt deze code niet in Markdown, wel in een gewoon R-script.
+
 chem_fe_cond_basis <- chem.all %>%
     filter(chem_variable == "Fe"| chem_variable == "CondL" ) %>% 
     collect

--- a/src/miscellaneous/electroneutrality_interaction_fe.Rmd
+++ b/src/miscellaneous/electroneutrality_interaction_fe.Rmd
@@ -1,0 +1,174 @@
+---
+title: "Electroneutrality interaction with Fe"
+author: "Jan Wouters"
+date: "17 september 2019"
+output: 
+    html_document: default
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(
+	cache = FALSE,
+	cache.path = "cache/",
+	dpi = 300,
+	include = TRUE
+)
+
+options(stringsAsFactors = FALSE)
+
+library(watina)
+library(tidyverse)
+library(ggplot2)
+library(knitr)
+
+```
+We willen hier nagaan of onvoldoende electroneutraal staal toch niet (deels) bruikbaar is voor (sommige) analyses. Meer bepaald de invloed van ijzer op de electroneutraliteit zal hier bekeken worden, omdat het bekend is dat vooral in ionenarme wateren neerslag van dit element (door oxidatie) voor een onevenwicht kan zorgen. In dat geval betekent gebrek aan electroneutraliteit (en), een te hoge en,  nog niet dat heel het staal kwalitatief slecht is. Het en-criterium is in dit geval niet goed toepasbaar. 
+De vraag die we hier willen beantwoorden, is of er een drempelwaarde van Fe is, waarboven de kans op een te hoge en veroorzaakt door Fe reëel is. 
+
+Volgende stappen werden gezet:
+
+### selectie van data (meetpunten en chemische data) op de SQL-server
+
+De chemische data worden in equivalenten weergegeven.
+```{r inlezen data, echo=TRUE}
+watina <- connect_watina()
+
+tubes_watina <- get_locs(watina, loc_type = "P", loc_validity = c("VLD", "ENT"), collect = FALSE)
+#loc_type = "P": enkel grondwatermeetpunten
+tubes_watina %>% count()
+
+chem.all <- get_chem(tubes_watina,watina,"1/1/1900", conc_type = "eq", collect = FALSE, strict_en = FALSE, en_range = c(-1, 1))
+
+```
+
+Overzicht van de chemische variabelen
+```{r chemische variabelen, eval=TRUE, include=TRUE}
+#om een voor mij onbekende reden werkt deze code niet in Markdown, wel in een gewoon R-script.
+
+chem_var <- chem.all %>%
+    select(chem_variable) %>%
+    distinct %>%
+    collect()
+
+kable(chem_var, format = "html") %>% 
+        kableExtra::kable_styling(bootstrap_options = c("striped", "hover", "condensed", "responsive"), 
+                  full_width = FALSE, 
+                  position = "left",
+                  font_size = 12,
+                  fixed_thead = T) %>%
+  kableExtra::scroll_box(height = "200px") 
+```
+
+De functie get_chem resulteert in een lange tabel-versie van alle chemische data. De electroneutraliteit is een metadata-gegeven op het niveau van labostaal.
+Uit deze tabel filteren we de Fe- en de conductiviteitsmetingen (in het labo uitgevoerd). Deze data worden geïmporteerd en omgezet naar een brede  ('tidy')tabel.
+
+```{r filter fe cond, eval=TRUE, include=TRUE}
+#om een voor mij onbekende reden werkt deze code niet in Markdown, wel in een gewoon R-script.
+chem_fe_cond_basis <- chem.all %>%
+    filter(chem_variable == "Fe"| chem_variable == "CondL" ) %>% 
+    collect
+
+```
+
+```{r chemdata breed, echo=TRUE}
+chem.fe_cond <- reshape::cast(chem_fe_cond_basis,
+                              formula = loc_code + lab_sample_id + date + elneutr~
+                                  chem_variable, value = "value", length)
+```
+
+Er zijn enkele stalen waar voor Fe en/of condL er twee meetwaarden bestaan. Omdat niet kan uitgemaakt worden welke van de twee meetwaarden juist is, worden deze stalen uitgesloten.
+
+```{r dubbels weren, echo=TRUE}
+chem_weg <- chem.fe_cond %>%
+    filter(CondL > 1 | Fe >1) %>%
+    select(lab_sample_id)
+
+chem.fe_cond <- reshape::cast(chem_fe_cond_basis %>%
+                              anti_join(chem_weg, by = "lab_sample_id"),
+                              formula = loc_code + lab_sample_id + date +elneutr~
+                                  chem_variable, value = "value", first)
+
+```
+
+Berekenen van de verhouding Fe/CondL
+
+```{r Fe-CondL-verhouding, echo=TRUE}
+chem.fe_cond <- chem.fe_cond %>%
+    mutate(fe.cond = Fe / CondL)
+```
+Een eerste ruwe plot
+```{r ruwe plot, echo=TRUE, warning=FALSE}
+graf <- ggplot(chem.fe_cond %>% filter(elneutr > 0.1), aes(x = fe.cond, y = elneutr)) +
+    geom_point()
+graf
+```
+Hier zie je een stijging van de en-afwijking bij toename van het Fe-gehalte in de totale ionenconcentratie.
+
+In een volgende grafiek wordt de verhouding van electroneutrale stalen tov het totaal aantal stalen per fe/cond-verhouding getoond. 
+
+```{r plot goed tov fe-cond, echo=TRUE}
+chem.fec_en <- chem.fe_cond %>%
+    mutate(fe.cond.round = signif(fe.cond,2)) %>%
+    filter(!is.na(elneutr) & fe.cond>0) %>%
+    group_by(fe.cond.round) %>%
+    mutate(aantal = n()) %>%
+    mutate(good = sum(ifelse(abs(elneutr) <= 0.1,1,0))/aantal) %>%
+    ungroup()
+
+graf.good <- ggplot(chem.fec_en , aes(x = fe.cond, y = good, size = aantal)) +
+    geom_point()
+graf.good
+
+```
+In de volgende grafiek wordt wat ingezoomd, door de x-waarden op de grafiek te beperken tot 0.02.
+```{r plot goed tov fe-cond zoom, echo=TRUE, message=FALSE, warning=FALSE}
+graf.good <- ggplot(chem.fec_en %>% 
+                        filter(fe.cond < 0.02), aes(x = fe.cond, y = good, size = aantal)) + geom_point() + geom_smooth()
+graf.good
+```
+
+Hier zie je toch wel twee opmerkelijke zaken:
+
+1. Er is een duidelijk negatief verband tussen het percentage en-stalen en de fe-cond-verhouding.
+1. Bij een lage fe-cond verhouding hebben de waterstalen meestal een goede en !
+
+Als drempelwaarde kan Fe/Cond = `r drempel <- 0.0023; drempel` voorgesteld worden. Deze drempelwaarde is wat door trial en error bepaald. Gezocht werd naar de waarde waarbij de gemiddelde waarde van en = 0.1
+Beperken we de grafiek tot de stalen die boven deze drempelwaarde zitten.
+```{r plot fe-cond boven drempel}
+graf.good <- ggplot(chem.fec_en %>% filter(fe.cond<0.05 & fe.cond >= drempel), aes(x= fe.cond, y = good, size = aantal)) +
+    geom_point() + geom_smooth()
+graf.good
+```
+Een tabel met een kleine basisstatistiek voor twee groepen: een groep met fe/cond < drempel en een groep met een fe/cond >= drempel
+```{r stat, echo=TRUE}
+basisstat <- chem.fec_en %>%
+    mutate(felaag = ifelse(fe.cond < drempel, 1,0)) %>%
+    group_by(felaag) %>%
+    summarise(en.mean = mean(elneutr),
+              en.sd = sd(elneutr)) %>% 
+    kable()
+basisstat
+```
+
+Klopt de stelling dat de meeste van deze punten op Diestiaanzanden gelegen zijn ?
+Onderstaande tabel onderschrijft deze stelling. Er zijn ook wel enkele mogelijke afwijkingen (bijv. DYL?).
+
+
+```{r check gebieden}
+check.gebieden <- chem.fec_en %>%
+    filter(fe.cond >= drempel) %>%
+    mutate(gebied = substr(loc_code,1,3)) %>%
+    group_by(gebied) %>%
+    count() %>%
+    arrange(desc(n)) %>% 
+    rename(aantal_stalen_groter_of_gelijk_aan_drempel = n) %>% 
+    kable(      caption = "Aantal stalen met fe/cond boven de drempelwaarde ", format = "html") %>% 
+    kableExtra::kable_styling(bootstrap_options = c("striped", "hover", "condensed", "responsive"), 
+                  full_width = FALSE, 
+                  position = "left",
+                  font_size = 12,
+                  fixed_thead = T) %>%
+  kableExtra::scroll_box(height = "200px") 
+check.gebieden
+```
+


### PR DESCRIPTION
There seems to be a quite reliable relation between this ratio and the electroneutrality.
Quite remarkable (and good) news is that a relative high Fe-concentration is one of the main reasons why a sample isn't electroneutral.
This cutlevel can be incorporated in the get_chem-function (watina-package).