### PR TITLE
Change terminology patch

### DIFF
--- a/src/generate_habitatmap_stdized/10_generate_habmap_stdized.Rmd
+++ b/src/generate_habitatmap_stdized/10_generate_habmap_stdized.Rmd
@@ -47,7 +47,7 @@ Every polygon in the habitat map can consist of maximum 5 different vegetation t
 
 We will convert the attribute table to a long format, so that every row contains one vegetation type.
 
-For some patches the vegetation type is uncertain, and 2 or 3 possible vegetation types are provided, separated with a ','. We will split the different possible vegetation types and create one row for each of them. An additional variable 'certain' will be FALSE if a patch consists of 2 or 3 possible vegetation types, and TRUE if only one vegetation type is provided.
+In some cases, the vegetation type is uncertain, and 2 or 3 possible vegetation types are provided, separated with a ','. We will split the different possible vegetation types and create one row for each of them. An additional variable 'certain' will be FALSE if the orginal habitatmap code consists of 2 or 3 possible vegetation types, and TRUE if only one vegetation type is provided.
 
 
 ```{r select_polygons}
@@ -109,29 +109,12 @@ habmap_long <- habmap_longHAB %>%
     filter(!(type %in% c("gh", "bos"))) %>%
     select(-patch_id)
 
-# habmap_long <- habmap_long %>%
-#     rename(type = type) %>%
-#     mutate(classtype = ifelse( str_sub(vegtype, 1,3) == "rbb",
-#                              "rbb",
-#                              "hab"),
-#            habtype = ifelse(classtype == "hab",
-#                             str_sub(vegtype, 1, 4),
-#                             NA),
-#            habsubtype = ifelse(classtype == "hab" &
-#                                    str_sub(vegtype, 5, 5) == "_",
-#                             vegtype,
-#                             NA),
-#            patch_area = polygon_area * phab / 100) %>%
-#     select(polygon_id,  patch_id, phab, code_orig,
-#            uncertain, vegtype, classtype, habtype, habsubtype,
-#            polygon_area, patch_area) %>%
-#     arrange(polygon_id, patch_id)
 
 ```
 
-## Select patches with types that belong to the standard list of habitat and rbb types  
+## Select vegetation types that belong to the standard list of habitat and rbb types  
 
-Table \@ref(tab:select_types) shows the patches with habitat types that do not belong to the standar list of habitat and rbb types. These records are filtered out. 
+Table \@ref(tab:select_types) shows the records with habitat types that do not belong to the standar list of habitat and rbb types. These records are filtered out. 
 
 ```{r select_types}
 

--- a/src/generate_habitatmap_stdized/10_generate_habmap_stdized.Rmd
+++ b/src/generate_habitatmap_stdized/10_generate_habmap_stdized.Rmd
@@ -5,8 +5,11 @@ The shapefile of the BWK and Natura 2000 habitat map of Flanders can be download
 
 ```{r read_raw_data}
 
-habmap_sf <- st_read("../../n2khab_data/10_raw/habitatmap", "habitatmap")
+path <- fileman_up("n2khab_data")
+file <- "10_raw/habitatmap"
 
+habitatmap_sf <- st_read(file.path(path, file),
+                  layer = "habitatmap")
 ```
 
 ## Correction of some of the codes in the Habitat map
@@ -40,9 +43,9 @@ habmap_correction %>%
 
 ## Processing of the attribute table
 
-Every polygon in the habitat map can consist of maximum 5 different vegetation types. This information is stored in the columns 'HAB1', 'HAB2',..., 'HAB5' of the attribute table. The fraction of each vegetation type within the polygons is stored in the columns 'PHAB1', 'PHAB2', ..., 'PHAB5'. We will call these different fractions 'patches'. 
+Every polygon in the habitat map can consist of maximum 5 different vegetation types. This information is stored in the columns 'HAB1', 'HAB2',..., 'HAB5' of the attribute table. The estimated fraction of each vegetation type within the polygons is stored in the columns 'PHAB1', 'PHAB2', ..., 'PHAB5'.
 
-We will convert the attribute table to a long format, so that every row contains one patch. A new variable is created to store the patch number (1 to 5): 'patch_id'.
+We will convert the attribute table to a long format, so that every row contains one vegetation type.
 
 For some patches the vegetation type is uncertain, and 2 or 3 possible vegetation types are provided, separated with a ','. We will split the different possible vegetation types and create one row for each of them. An additional variable 'certain' will be FALSE if a patch consists of 2 or 3 possible vegetation types, and TRUE if only one vegetation type is provided.
 
@@ -103,7 +106,8 @@ habmap_long <- habmap_longHAB %>%
              remove = FALSE) %>%
     gather(type1, type2, type3, key = "ntype", value = "type") %>%
     filter(!is.na(type)) %>%
-    filter(!(type %in% c("gh", "bos")))
+    filter(!(type %in% c("gh", "bos"))) %>%
+    select(-patch_id)
 
 # habmap_long <- habmap_long %>%
 #     rename(type = type) %>%
@@ -139,18 +143,18 @@ habmap_long <- habmap_long %>%
 
 habmap_types <- habmap_long %>%
   filter(!is.na(typelevel)) %>%
-   select(polygon_id, patch_id, code_orig = code, phab, certain, type) %>%
+   select(polygon_id, code_orig = code, phab, certain, type) %>%
   mutate(type = factor(type,
                        levels = levels(types$type)
                        )
          ) %>%
-  arrange(polygon_id, patch_id)
+  arrange(polygon_id, desc(phab))
   
 habmap_other_type <- habmap_long %>%
   filter(is.na(typelevel))
 
 habmap_other_type %>%
-  select(polygon_id, patch_id, code, phab, certain, type) %>%
+  select(polygon_id, code, phab, certain, type) %>%
   kable() %>%
   kable_styling()
 
@@ -170,12 +174,12 @@ habmap_types_sf <- habmap_sf %>%
 
 ```{r}
 
-st_write(habmap_types_sf, "../../n2khab_data/20_processed/habitatmap_stdized/habitatmap_stdized.gpkg", layer = "habitatmap_polygons", driver = "GPKG")
+st_write(habmap_types_sf, file.path(path,"20_processed/habitatmap_stdized/habitatmap_stdized.gpkg"), layer = "habitatmap_polygons", driver = "GPKG")
 
 con = dbConnect(SQLite(),
-                dbname = "../../n2khab_data/20_processed/habitatmap_stdized/habitatmap_stdized.gpkg")
+                dbname = file.path(path,"20_processed/habitatmap_stdized/habitatmap_stdized.gpkg"))
 
-dbWriteTable(con, "habitatmap_patches", habmap_types)
+dbWriteTable(con, "habitatmap_types", habmap_types)
 
 dbDisconnect(con)
 

--- a/src/generate_watersurfaces_hab/10_generate_watersurfaces_hab.Rmd
+++ b/src/generate_watersurfaces_hab/10_generate_watersurfaces_hab.Rmd
@@ -1,6 +1,6 @@
 # Generate map of watersurfaces that contain aquatic habitat
 
-We will create a map with watersurfaces that contain aquatic habitat and rib. The structure of the map will be similar to the processed habitatmap of Flanders: it will consist of spatial file that contains the polygons and a table with the different habitat 'patches' within the polygons.  
+We will create a map with watersurfaces that contain aquatic habitat and rib. The structure of the map will be similar to the processed habitatmap of Flanders: it will consist of spatial file that contains the polygons and a table with the different types within the polygons.  
 
 ## Data sources
 
@@ -50,11 +50,11 @@ For habitat sutbtype 2190_a we select all water surfaces within habitat map poly
 
 ```{r select dune habitat polygons}
 
-habitatmap_21xx_patches <- habmap$habitatmap_patches %>%
+habitatmap_21xx_types <- habmap$habitatmap_types %>%
   filter((str_sub(type, 1, 2) == "21")) 
 
 habitatmap_21xx_polygons<- habmap$habitatmap_polygons %>%
-  filter(polygon_id %in% habitatmap_21xx_patches$polygon_id)
+  filter(polygon_id %in% habitatmap_21xx_types$polygon_id)
 
 ```
 
@@ -85,10 +85,10 @@ intersection_ws_21xx <- watersurfaces_21xx %>%
     st_intersection(habitatmap_21xx_polygons) %>%
     select(polygon_id_ws, polygon_id, description_orig)
 
-watersurfaces_2190_a_patches <- intersection_ws_21xx %>%
+watersurfaces_2190_a_types <- intersection_ws_21xx %>%
     st_drop_geometry() %>%
     # add 'description_orig' attribute
-    left_join(habitatmap_21xx_patches, by = "polygon_id") %>% 
+    left_join(habitatmap_21xx_types, by = "polygon_id") %>% 
     rename(polygon_id_habitatmap = polygon_id) %>%
     distinct(polygon_id_ws, polygon_id_habitatmap, description_orig) %>%
     mutate(type = "2190_a") %>%
@@ -98,7 +98,7 @@ watersurfaces_2190_a_patches <- intersection_ws_21xx %>%
     ungroup() 
 
 # we will add the description_orig attribute to the object that contains the polygons (analogous to habitatmap_stdized)
-description <- watersurfaces_2190_a_patches %>%
+description <- watersurfaces_2190_a_types %>%
     distinct(polygon_id_ws, polygon_id_habitatmap, description_orig)
 
 watersurfaces_2190_a_polygons <- watersurfaces_21xx %>%
@@ -110,13 +110,12 @@ watersurfaces_2190_a_polygons <- watersurfaces_21xx %>%
 check_unique_polygon <- nrow(watersurfaces_2190_a_polygons) == n_distinct(watersurfaces_2190_a_polygons$geometry)
 check_unique_polygon
 
-watersurfaces_2190_a_patches <- watersurfaces_2190_a_patches %>%
+watersurfaces_2190_a_types <- watersurfaces_2190_a_types %>%
     select(-description_orig) %>%
-    mutate(patch_id = 1,
-           code_orig = NA,
+    mutate(code_orig = NA,
            certain = TRUE,
            polygon_id = polygon_id_ws) %>%
-    select(polygon_id, patch_id, code_orig, certain, type)
+    select(polygon_id, code_orig, certain, type)
 
 
 ```
@@ -129,11 +128,11 @@ standing_water <- read_types() %>%
     filter(tag_1 == "SW" | type == "7220") %>%
     filter(main_type != "2190")
 
-habitatmap_standw_patches <- habmap$habitatmap_patches %>%
+habitatmap_standw_types <- habmap$habitatmap_types %>%
   filter(type %in% standing_water$type) 
 
 habitatmap_standw_polygons <- habmap$habitatmap_polygons %>%
-  filter(polygon_id %in% habitatmap_standw_patches$polygon_id)
+  filter(polygon_id %in% habitatmap_standw_types$polygon_id)
 
 watersurfaces_standw <- watersurfaces[habitatmap_standw_polygons,] 
 
@@ -146,7 +145,7 @@ check_id
 
 We create the water surface map with standing water habitat in a very similar way than the 2190_a map.
 
-For each water surface we will create a patch for every standing water habitat type that occurs in the water surface according to the habitat map. We do not attempt to calculate a phab for the different patches. 
+For each water surface we will create a record for every standing water habitat type that occurs in the water surface according to the habitat map. We do not attempt to calculate a phab for the different types. 
 
 ```{r}
 
@@ -154,9 +153,9 @@ intersection_ws_standw <- watersurfaces_standw %>%
     st_intersection(habitatmap_standw_polygons) %>%
     select(polygon_id_ws, polygon_id, description_orig)
 
-watersurfaces_standw_patches <- intersection_ws_standw %>%
+watersurfaces_standw_types <- intersection_ws_standw %>%
     st_drop_geometry() %>%
-    left_join(habitatmap_standw_patches, by = "polygon_id") %>%
+    left_join(habitatmap_standw_types, by = "polygon_id") %>%
     rename(polygon_id_habitatmap = polygon_id) %>%
     distinct(polygon_id_ws, polygon_id_habitatmap, description_orig, code_orig, certain, type) %>%
     group_by(polygon_id_ws, code_orig, certain, type) %>%
@@ -164,16 +163,15 @@ watersurfaces_standw_patches <- intersection_ws_standw %>%
            description_orig =  str_c(description_orig, collapse = "+")) %>%
     ungroup() %>%
     group_by(polygon_id_ws) %>%
-    mutate(patch_id = rank(code_orig),
-           polygon_id_habitatmap = str_c(polygon_id_habitatmap, collapse = "+"),
+    mutate(polygon_id_habitatmap = str_c(polygon_id_habitatmap, collapse = "+"),
            description_orig =  str_c(description_orig, collapse = "+")) %>%
     ungroup()
 
-description <- watersurfaces_standw_patches %>%
+description <- watersurfaces_standw_types %>%
     distinct(polygon_id_ws, polygon_id_habitatmap, description_orig)
 
 watersurfaces_standw_polygons <- watersurfaces_standw %>%
-    # filter(polygon_id_ws %in% watersurfaces_standw_patches$polygon_id_ws) %>%
+    # filter(polygon_id_ws %in% watersurfaces_standw_types$polygon_id_ws) %>%
     left_join(description, by = "polygon_id_ws") %>%
     mutate(polygon_type = "watersurface map") %>%
     select(polygon_id_ws, polygon_id_habitatmap, description_orig, polygon_type)
@@ -182,7 +180,7 @@ check_unique_polygon <- nrow(watersurfaces_standw_polygons) == n_distinct(waters
 
 check_unique_polygon
     
-watersurfaces_standw_patches <- watersurfaces_standw_patches %>%
+watersurfaces_standw_types <- watersurfaces_standw_types %>%
     select(-description_orig)
 
 
@@ -201,7 +199,7 @@ habitatmap_standw_polygons_no_ws <- habitatmap_standw_polygons %>%
     mutate(polygon_id_ws = NA,
            polygon_type = "habitatmap")
 
-habitatmap_standw_patches_no_ws <- habitatmap_standw_patches %>%
+habitatmap_standw_types_no_ws <- habitatmap_standw_types %>%
     filter(!polygon_id %in% intersection_ws_standw$polygon_id) %>%
     mutate(polygon_id_habitatmap = polygon_id,
            polygon_id_ws = NA) %>%
@@ -233,12 +231,12 @@ leaflet(habitatmap_standw_polygons_no_ws %>%
 
 ```{r}
 
-habmap_standw_patches <- watersurfaces_standw_patches %>%
-    bind_rows(habitatmap_standw_patches_no_ws) %>%
+habmap_standw_types <- watersurfaces_standw_types %>%
+    bind_rows(habitatmap_standw_types_no_ws) %>%
     mutate(polygon_id = ifelse(is.na(polygon_id_ws),
                                as.character(polygon_id_habitatmap),
                                as.character(polygon_id_ws))) %>%
-    select(polygon_id,  patch_id, everything())
+    select(polygon_id, everything())
 
 habmap_standw_polygons <- watersurfaces_standw_polygons %>%
     rbind(habitatmap_standw_polygons_no_ws) %>%
@@ -252,9 +250,9 @@ habmap_standw_polygons <- watersurfaces_standw_polygons %>%
 ## Combine 31xx/7220 and 2190_a map
 
 ```{r}
-watersurfaces_hab_patches <- habmap_standw_patches %>%
-    bind_rows(watersurfaces_2190_a_patches) %>%
-    select(polygon_id, patch_id, code_orig, certain, type)
+watersurfaces_hab_types <- habmap_standw_types %>%
+    bind_rows(watersurfaces_2190_a_types) %>%
+    select(polygon_id, code_orig, certain, type)
 
 watersurfaces_hab_polygons <- habmap_standw_polygons %>%
     rbind(watersurfaces_2190_a_polygons) %>%
@@ -292,7 +290,7 @@ st_write(watersurfaces_hab_polygons, file.path(path, "20_processed/watersurfaces
 con = dbConnect(SQLite(),
                 dbname = file.path(path, "20_processed/watersurfaces_hab/watersurfaces_hab.gpkg"))
 
-dbWriteTable(con, "watersurfaces_hab_patches", watersurfaces_hab_patches)
+dbWriteTable(con, "watersurfaces_hab_types", watersurfaces_hab_types)
 
 dbDisconnect(con)
 

--- a/src/generate_watersurfaces_hab/sessioninfo.txt
+++ b/src/generate_watersurfaces_hab/sessioninfo.txt
@@ -22,7 +22,7 @@ crayon 1.3.4 2017-09-16
 crosstalk 1.0.1 2019-05-03 Github (rstudio/crosstalk@feaf86b)
 curl 4.0 2019-07-22 
 data.table 1.12.2 2019-04-07 
-DBI 1.0.0.9001 2019-05-23 Github (r-dbi/DBI@3873e3d)
+DBI 1.0.0.9002 2019-10-02 Github (r-dbi/DBI@6f34ab4)
 desc 1.2.0 2018-05-01 
 devtools 2.1.0 2019-07-06 
 digest 0.6.20 2019-07-04 
@@ -31,18 +31,20 @@ e1071 1.7-2 2019-06-05
 evaluate 0.14 2019-05-28 
 forcats 0.4.0 2019-02-17 
 foreach 1.4.7 2019-07-27 
+fortunes 1.5-4 2016-12-29 
 fs 1.3.1 2019-05-06 
 gdalUtils 2.0.1.14 2018-04-23 
 generics 0.0.2 2018-11-29 
 geoaxe 0.1.0 2016-02-19 
 ggplot2 3.2.1 2019-08-10 
 git2r 0.26.1 2019-06-29 
-git2rdata 0.1 2019-07-30 Github (inbo/git2rdata@9233a59)
+git2rdata 0.1.0.9000 2019-10-02 Github (inbo/git2rdata@2495573)
 glue 1.3.1 2019-03-12 
 googlesheets 0.3.0 2018-06-29 
 gtable 0.3.0 2019-03-25 
 haven 2.1.1 2019-07-04 
-hms 0.5.0 2019-07-09 
+highr 0.8 2019-03-20 
+hms 0.5.1 2019-08-23 
 htmltools 0.3.6 2017-04-28 
 htmlwidgets 1.3 2018-09-30 
 httpuv 1.5.1 2019-04-05 
@@ -63,14 +65,14 @@ memoise 1.1.0 2017-04-21
 mime 0.7 2019-06-11 
 modelr 0.1.5 2019-08-08 
 munsell 0.5.0 2018-06-12 
-n2khab 0.0.3.9024 2019-09-24 Github (inbo/n2khab@7f2c967)
+n2khab 0.0.3.9028 2019-10-02 Github (inbo/n2khab@a658cff)
 nlme 3.1-137 2018-04-07 
 oai 0.2.2 2016-11-24 
 odbc 1.1.6 2018-06-09 
 pander 0.6.3 2018-11-06 
 pillar 1.4.2 2019-06-29 
 pkgbuild 1.0.4 2019-08-05 
-pkgconfig 2.0.2 2018-08-16 
+pkgconfig 2.0.3 2019-09-22 
 pkgload 1.0.2 2018-10-29 
 plyr 1.8.4 2016-06-08 
 prettyunits 1.0.2 2015-07-13 
@@ -82,7 +84,7 @@ R.methodsS3 1.7.1 2016-02-16
 R.oo 1.22.0 2018-04-22 
 R.utils 2.9.0 2019-06-13 
 R6 2.4.0 2019-02-14 
-raster 2.9-23 2019-07-11 
+raster 3.0-7 2019-09-24 
 Rcpp 1.0.2 2019-07-25 
 readr 1.3.1 2018-12-21 
 readxl 1.3.1 2019-03-13 
@@ -98,7 +100,7 @@ rstudioapi 0.10 2019-03-19
 rvest 0.3.4 2019-05-15 
 scales 1.0.0 2018-08-09 
 sessioninfo 1.1.1 2018-11-05 
-sf 0.7-7 2019-07-24 
+sf 0.8-0 2019-09-17 
 shiny 1.3.2 2019-04-22 
 sp 1.3-1 2018-06-05 
 stringi 1.4.3 2019-03-12 


### PR DESCRIPTION
The changes result in a new version of habitatmap_stdized (v2) and watersurfaces_hab (v3). The new versions can be found on the Q-drive. 
After merging, I will upload the new versions to Zenodo.

In order to read the new versions the functions read_watersurfaces_hab and read_habitatmap_stdized had to be changed. I will create a pull request in the n2khab repository for this. 
  