### PR TITLE
Generating habitatmap_terr: version 'habitatmap_terr_2018_v2'

### DIFF
--- a/src/generate_habitatmap_terr/20_generate_habmap_terr_interpreted.Rmd
+++ b/src/generate_habitatmap_terr/20_generate_habmap_terr_interpreted.Rmd
@@ -33,7 +33,9 @@ habmap_stdized <- read_habitatmap_stdized()
 
 habmap_polygons <- habmap_stdized$habitatmap_polygons
 
-habmap_patches <- habmap_stdized$habitatmap_patches
+# following requires at least n2khab 0.0.3.9037 and 
+# data source version habitatmap_stdized_2018_v2:
+habmap_types <- habmap_stdized$habitatmap_types 
 
 ```
 
@@ -54,11 +56,11 @@ Rbbhfl is a code which needs interpretation from BWK + habitatmap, in order to m
 
 ```{r detect rbbhfl}
 
-#filter hfl-patches from bwk units
+#filter hfl-types from bwk units
 habmap_hfl <- habmap_sf  %>% 
-    inner_join(habmap_patches, by = c("TAG" = "polygon_id"))%>% 
+    inner_join(habmap_types, by = c("TAG" = "polygon_id")) %>% 
     mutate(rbbhfl = str_detect(BWKLABEL, "hfl")) %>% 
-    select(TAG, BWKLABEL, rbbhfl, type, code_orig, patch_id) %>% 
+    select(TAG, BWKLABEL, rbbhfl, type, code_orig) %>% 
     filter(rbbhfl == TRUE & type == "rbbhf") 
 
 #update habmap_polygons -> habmap_polygons_interpreted
@@ -70,11 +72,11 @@ habmap_polygons_interpreted <- habmap_polygons %>%
            source = ifelse(is.na(rbbhfl), "habitatmap_stdized", "habitatmap_stdized + interpretation")) %>% 
     select(-rbbhfl)
 
-#update habmap_patches -> habmap_patches_interpreted
-habmap_patches_interpreted <- habmap_patches %>% 
+#update habmap_types -> habmap_types_interpreted
+habmap_types_interpreted <- habmap_types %>% 
     left_join(habmap_hfl %>% 
-                  select(TAG, patch_id, rbbhfl) %>% 
-                   st_drop_geometry(), by = c("polygon_id" = "TAG", "patch_id" = "patch_id")) %>% 
+                  select(TAG, rbbhfl) %>% 
+                   st_drop_geometry(), by = c("polygon_id" = "TAG")) %>% 
     mutate(type = ifelse(is.na(rbbhfl) | type != "rbbhf", as.character(type), str_replace_all(type, "rbbhf", "rbbhfl")),
            source = ifelse(is.na(rbbhfl) | type != "rbbhfl", "habitatmap_stdized", "habitatmap_stdized + interpretation")) %>% 
     select(-rbbhfl) 
@@ -97,9 +99,9 @@ It's possible that a watersurface is being mapped together with other biotopes. 
 
 ```{r detect dune water}
 habmap_dunewater <- habmap_sf %>% 
-    inner_join(habmap_patches_interpreted, by = c("TAG" = "polygon_id")) %>% 
+    inner_join(habmap_types_interpreted, by = c("TAG" = "polygon_id")) %>% 
     mutate(dunewater = str_detect(EENH1, c("ae|kn"))) %>% 
-    select(TAG, BWKLABEL, dunewater, type, code_orig, patch_id) %>% 
+    select(TAG, BWKLABEL, dunewater, type, code_orig) %>% 
     filter(dunewater == TRUE & type == "2190") 
 
 #update habmap_polygons -> habmap_polygons_interpreted
@@ -119,11 +121,11 @@ habmap_polygons_interpreted <- habmap_polygons_interpreted %>%
     mutate(description = str_replace_all(description, "2191", "2190")) %>% 
     select(-dunewater)
 
-#update habmap_patches -> habmap_patches_interpreted
-habmap_patches_interpreted <- habmap_patches_interpreted %>% 
+#update habmap_types -> habmap_types_interpreted
+habmap_types_interpreted <- habmap_types_interpreted %>% 
     left_join(habmap_dunewater %>% 
-                  select(TAG, patch_id, dunewater) %>% 
-                   st_drop_geometry(), by = c("polygon_id" = "TAG", "patch_id" = "patch_id")) %>% 
+                  select(TAG, dunewater) %>% 
+                   st_drop_geometry(), by = c("polygon_id" = "TAG")) %>% 
     mutate(type = str_replace_all(type, "2190_", "2191_")) %>% # mark mappings on subtype-level
     mutate(type = case_when(
                     is.na(dunewater) & str_detect(type, "2190") ~ "2190_overig", 
@@ -152,22 +154,22 @@ This applies to the following cases:
 * code_orig is 6510,gh or 9120,gh
 
 ```{r exclude some uncertain mapping units}
-habmap_patches_interpreted <- 
-    habmap_patches_interpreted %>%
+habmap_types_interpreted <- 
+    habmap_types_interpreted %>%
     filter(!str_detect(code_orig, "bos") & !(code_orig %in% c("6510,gh", "9120,gh")))
 habmap_polygons_interpreted <- 
     habmap_polygons_interpreted %>%
-    semi_join(habmap_patches_interpreted, by = "polygon_id")
+    semi_join(habmap_types_interpreted, by = "polygon_id")
 ```
 
 ## Exclude water surfaces
 
 This interpreted version of the habitat map contains only terrestrial biotopes. The interpreted water surfaces are returned by `read_watersurfaces_hab(interpreted = TRUE)`.
 The standardized habitatmap contains also watersurfaces (streaming water are much less mapped). They have therefore to be excluded from the interpreted terrestrial version.
-By using habitatmap_stdized we actually can never be sure about 'pure' water, because patches were already dropped from non-dropped polygons before:
+By using habitatmap_stdized we actually can never be sure about 'pure' water, because types were already dropped from non-dropped polygons before:
 
-* in generating habitatmap_stdized, only patches containing a habitat or RIB code have been retained, others were dropped (such as gh, x and bos) ;
-* patches containing "bos", or being one of "6510,gh", "9120,gh" were already omitted.
+* in generating habitatmap_stdized, only rows where `code_orig` contains a habitat or RIB code have been retained, others were dropped (such as gh, x and bos) ;
+* rows where `code_orig` contains "bos" or is one of "6510,gh", "9120,gh" were already omitted.
 
 It means we will actually drop polygons which, besides water types, _contain no other habitat or rib_. And that still matches our aim, i.e. terrestrial habitats / rib
 
@@ -179,7 +181,7 @@ watertypes <- data.frame( "watertype" = c("1130", "2190_a", "3110", "3130", "313
 # fyi: polygons with a very small portion of watersurface that for the remaining part are terrestrial non(!)-habitat/rib are excluded
 
 habmap_polygons_water <- 
-    habmap_patches_interpreted %>% 
+    habmap_types_interpreted %>% 
     group_by(polygon_id) %>% 
     mutate(oppsum = sum(phab)) %>% 
     semi_join(watertypes, by = c("type" = "watertype")) %>% 
@@ -191,7 +193,7 @@ habmap_polygons_water <-
 habmap_polygons_interpreted <- habmap_polygons_interpreted %>% 
     anti_join(habmap_polygons_water)
 
-habmap_patches_interpreted <- habmap_patches_interpreted %>% 
+habmap_types_interpreted <- habmap_types_interpreted %>% 
     anti_join(habmap_polygons_water)    
 
 
@@ -236,7 +238,7 @@ habmap_polygons_interpreted <- habmap_polygons_interpreted %>%
     mutate( description = str_replace_all(description, "µ_", "0_")) %>% 
     mutate( source =  as.factor(source))
 
-habmap_patches_interpreted <- habmap_patches_interpreted %>% 
+habmap_types_interpreted <- habmap_types_interpreted %>% 
     mutate(type = str_replace_all(type, c("6410_" = "641µ_",
                                                         "6430_" = "643µ_",
                                                         "6510_" = "651µ_",
@@ -282,7 +284,7 @@ con = dbConnect(SQLite(),
                   "20_processed/habitatmap_terr/habitatmap_terr.gpkg")
                 )
 
-dbWriteTable(con, "habitatmap_terr_patches", habmap_patches_interpreted)
+dbWriteTable(con, "habitatmap_terr_types", habmap_types_interpreted)
 
 dbDisconnect(con)
 ```

--- a/src/generate_habitatmap_terr/_bookdown.yml
+++ b/src/generate_habitatmap_terr/_bookdown.yml
@@ -1,0 +1,4 @@
+book_filename: "generating_habitatmap_terr.Rmd"
+new_session: FALSE
+rmd_files: # specifies the order of Rmd files; NOT needed when you use index.Rmd and an alphabetical order for other Rmd files
+    # - index.Rmd

--- a/src/generate_habitatmap_terr/sessioninfo.txt
+++ b/src/generate_habitatmap_terr/sessioninfo.txt
@@ -3,34 +3,34 @@ os	Linux Mint 18.1
 system	x86_64, linux-gnu
 ctype	nl_BE.UTF-8
 
-assertable 0.2.6 2019-09-12 
+assertable 0.2.7 2019-09-21 
 assertthat 0.2.1 2019-03-21 
-backports 1.1.4 2019-04-10 
+backports 1.1.5 2019-10-02 
 bit 1.1-14 2018-05-29 
 bit64 0.9-7 2017-05-08 
 blob 1.2.0 2019-07-09 
-bookdown 0.13 2019-08-21 
+bookdown 0.14 2019-10-01 
 broom 0.5.2 2019-04-07 
-callr 3.3.1 2019-07-18 
+callr 3.3.2 2019-09-22 
 cellranger 1.1.0 2016-07-27 
 class 7.3-15 2019-01-01 
-classInt 0.4-1 2019-08-06 
+classInt 0.4-2 2019-10-17 
 cli 1.1.0 2019-03-19 
 codetools 0.2-16 2018-12-24 
 colorspace 1.4-1 2019-03-18 
 crayon 1.3.4 2017-09-16 
 crosstalk 1.0.0 2016-12-21 
-curl 4.1 2019-09-16 
-data.table 1.12.2 2019-04-07 
-DBI 1.0.0.9002 2019-09-17 Github (r-dbi/DBI@0756bd6)
+curl 4.2 2019-09-24 
+data.table 1.12.6 2019-10-18 
+DBI 1.0.0.9003 2019-11-04 Github (r-dbi/DBI@6f871f1)
 desc 1.2.0 2018-05-01 
-devtools 2.2.0 2019-09-07 
-digest 0.6.20 2019-07-04 
+devtools 2.2.1 2019-09-24 
+digest 0.6.22 2019-10-21 
 dplyr 0.8.3 2019-07-04 
-DT 0.8 2019-08-07 
 e1071 1.7-2 2019-06-05 
-ellipsis 0.2.0.1 2019-07-02 
+ellipsis 0.3.0 2019-09-20 
 evaluate 0.14 2019-05-28 
+fastmap 1.0.1 2019-10-08 
 forcats 0.4.0 2019-02-17 
 foreach 1.4.7 2019-07-27 
 fs 1.3.1 2019-05-06 
@@ -44,18 +44,18 @@ glue 1.3.1 2019-03-12
 googlesheets 0.3.0.9000 2019-05-08 Github (jennybc/googlesheets@12abb02)
 gtable 0.3.0 2019-03-25 
 haven 2.1.1 2019-07-04 
-hms 0.5.1 2019-08-23 
-htmltools 0.3.6 2017-04-28 
-htmlwidgets 1.3 2018-09-30 
+hms 0.5.2 2019-10-30 
+htmltools 0.4.0 2019-10-04 
+htmlwidgets 1.5.1 2019-10-08 
 httpuv 1.5.2 2019-09-11 
 httr 1.4.1 2019-08-05 
-inborutils 0.1.0.9062 2019-09-20 Github (inbo/inborutils@4c0dc7a)
+inborutils 0.1.0.9062 2019-11-05 Github (inbo/inborutils@4c0dc7a)
 iterators 1.0.12 2019-07-26 
 jsonlite 1.6 2018-12-07 
 kableExtra 1.1.0 2019-03-16 
-KernSmooth 2.23-15 2015-06-29 
-knitr 1.24 2019-08-08 
-later 0.8.0 2019-02-11 
+KernSmooth 2.23-16 2019-10-15 
+knitr 1.25 2019-09-18 
+later 1.0.0 2019-10-04 
 lattice 0.20-38 2018-11-04 
 lazyeval 0.2.2 2019-05-08 Github (hadley/lazyeval@c336765)
 leaflet 2.0.2 2018-08-27 
@@ -66,35 +66,35 @@ memoise 1.1.0 2017-04-21
 mime 0.7 2019-06-11 
 modelr 0.1.5 2019-08-08 
 munsell 0.5.0 2018-06-12 
-n2khab 0.0.3.9024 2019-09-20 local
+n2khab 0.0.3.9036 2019-11-05 Github (inbo/n2khab@8c246c3)
 nlme 3.1-141 2019-08-01 
 oai 0.3.0 2019-09-07 
 odbc 1.1.6 2018-06-09 
 pander 0.6.3 2018-11-06 
 pillar 1.4.2 2019-06-29 
-pkgbuild 1.0.5 2019-08-26 
-pkgconfig 2.0.2 2018-08-16 
+pkgbuild 1.0.6 2019-10-09 
+pkgconfig 2.0.3 2019-09-22 
 pkgload 1.0.2 2018-10-29 
 plyr 1.8.4 2016-06-08 
 prettyunits 1.0.2 2015-07-13 
 processx 3.4.1 2019-07-18 
-promises 1.0.1 2018-04-13 
+promises 1.1.0 2019-10-04 
 ps 1.3.0 2018-12-21 
-purrr 0.3.2 2019-03-15 
+purrr 0.3.3 2019-10-18 
 R.methodsS3 1.7.1 2016-02-16 
-R.oo 1.22.0 2018-04-22 
+R.oo 1.23.0 2019-11-03 
 R.utils 2.9.0 2019-06-13 
 R6 2.4.0 2019-02-14 
-raster 3.0-2 2019-08-22 
+raster 3.0-7 2019-09-24 
 Rcpp 1.0.2 2019-07-25 
-readr 1.3.1.9000 2019-09-17 Github (tidyverse/readr@0384d87)
+readr 1.3.1.9000 2019-11-04 Github (tidyverse/readr@0fd92f8)
 readxl 1.3.1 2019-03-13 
 remotes 2.1.0 2019-06-24 
-rgbif 1.3.0 2019-05-08 
-rgdal 1.4-4 2019-05-29 
-rgeos 0.5-1 2019-08-05 
-rlang 0.4.0 2019-06-25 
-rmarkdown 1.15 2019-08-21 
+rgbif 1.4.0 2019-10-30 
+rgdal 1.4-7 2019-10-28 
+rgeos 0.5-2 2019-10-03 
+rlang 0.4.1 2019-10-24 
+rmarkdown 1.16 2019-10-01 
 rprojroot 1.3-2 2018-01-03 
 RSQLite 2.1.2 2019-07-24 
 rstudioapi 0.10 2019-03-19 
@@ -102,7 +102,7 @@ rvest 0.3.4 2019-05-15
 scales 1.0.0 2018-08-09 
 sessioninfo 1.1.1 2018-11-05 
 sf 0.8-0 2019-09-17 
-shiny 1.3.2 2019-04-22 
+shiny 1.4.0 2019-10-10 
 sp 1.3-1 2018-06-05 
 stringi 1.4.3 2019-03-12 
 stringr 1.4.0 2019-02-10 
@@ -111,14 +111,14 @@ tibble 2.1.3 2019-06-06
 tidyr 1.0.0 2019-09-11 
 tidyselect 0.2.5 2018-10-11 
 tidyverse 1.2.1 2017-11-14 
-units 0.6-4 2019-08-22 
+units 0.6-5 2019-10-08 
 usethis 1.5.1 2019-07-04 
 vctrs 0.2.0 2019-07-05 
 viridisLite 0.3.0 2018-02-01 
 webshot 0.5.1 2018-09-28 
 whisker 0.4 2019-08-28 
 withr 2.1.2 2018-03-15 
-xfun 0.9 2019-08-21 
+xfun 0.10 2019-10-01 
 xml2 1.2.2 2019-08-09 
 xtable 1.8-4 2019-04-21 
 yaml 2.2.0 2018-07-25 


### PR DESCRIPTION
As a follow-up to PR #29, the term 'patches' is discarded from `habitatmap_terr` as the term caused confusion. This means that the former table `habitatmap_terr_patches` has been renamed as `habitatmap_terr_types`, and that it loses its column `patch_id` (`patch_id` was a numeric identifier of unique values of `code_orig` (~ 'patches'), which can be repeated > 1 time for the same polygon).

The name `habitatmap_terr_types` better matches the actual meaning of this table's contents: it lists the types for each polygon. It contains no spatial definitions other than `polygon_id`.

The newly created version:

- is now the version provided at our internal location (Q-drive; see this [data distribution scheme](https://drive.google.com/file/d/1xZz9f9n8zSUxBJvW6WEFLyDK7Ya0u4iN/view))
- will be uploaded to Zenodo when this PR is merged
- is now accommodated by the function `n2khab::read_habitatmap_terr()`; also the old version is still accommodated when the default `version` argument is overridden. This needs at least `n2khab` at commit `1aa3f85` (cf. [this PR](https://github.com/inbo/n2khab/pull/39))
- has been compared to the previous version; it is exactly the same except for the mentioned update. See code below:

```r
library(n2khab) # requires at least n2khab@1aa3f85
library(tidyverse)
library(sf)
hmt_new <- read_habitatmap_terr()
hmt_old <- read_habitatmap_terr(file = "20_processed/habitatmap_terr_old/habitatmap_terr.gpkg",
                                version = "habitatmap_terr_2018_v1")

all.equal(hmt_old$habitatmap_terr_patches %>% select(-patch_id),
          hmt_new$habitatmap_terr_types)
# TRUE

all.equal(hmt_old$habitatmap_terr_polygons %>% st_drop_geometry,
          hmt_new$habitatmap_terr_polygons %>% st_drop_geometry)
# TRUE
```