### PR TITLE
habmap_terr/stdized & watsurf_hab: use DBI::dbConnect()

### DIFF
--- a/src/generate_habitatmap_stdized/10_generate_habmap_stdized.Rmd
+++ b/src/generate_habitatmap_stdized/10_generate_habmap_stdized.Rmd
@@ -159,7 +159,7 @@ habmap_types_sf <- habmap_sf %>%
 
 st_write(habmap_types_sf, file.path(path,"20_processed/habitatmap_stdized/habitatmap_stdized.gpkg"), layer = "habitatmap_polygons", driver = "GPKG")
 
-con = dbConnect(SQLite(),
+con = dbConnect(RSQLite::SQLite(),
                 dbname = file.path(path,"20_processed/habitatmap_stdized/habitatmap_stdized.gpkg"))
 
 dbWriteTable(con, "habitatmap_types", habmap_types)

--- a/src/generate_habitatmap_stdized/index.Rmd
+++ b/src/generate_habitatmap_stdized/index.Rmd
@@ -48,7 +48,7 @@ library(n2khab)
 library(git2rdata)
 library(googlesheets)
 library(kableExtra)
-library(RSQLite) 
+library(DBI) 
 
 opts_chunk$set(
   echo = TRUE,

--- a/src/generate_habitatmap_terr/20_generate_habmap_terr_interpreted.Rmd
+++ b/src/generate_habitatmap_terr/20_generate_habmap_terr_interpreted.Rmd
@@ -278,7 +278,7 @@ st_write(habmap_polygons_interpreted,
          driver = "GPKG",
          delete_dsn = TRUE)
 
-con = dbConnect(SQLite(),
+con = dbConnect(RSQLite::SQLite(),
                 dbname = file.path(
                   datapath, 
                   "20_processed/habitatmap_terr/habitatmap_terr.gpkg")

--- a/src/generate_habitatmap_terr/index.Rmd
+++ b/src/generate_habitatmap_terr/index.Rmd
@@ -48,7 +48,7 @@ library(n2khab)
 library(git2rdata)
 library(googlesheets)
 library(kableExtra)
-library(RSQLite) 
+library(DBI) 
 
 opts_chunk$set(
   echo = TRUE,

--- a/src/generate_watersurfaces_hab/10_generate_watersurfaces_hab.Rmd
+++ b/src/generate_watersurfaces_hab/10_generate_watersurfaces_hab.Rmd
@@ -287,7 +287,7 @@ if(!dir.exists(file.path(path, "20_processed/watersurfaces_hab"))){
 
 st_write(watersurfaces_hab_polygons, file.path(path, "20_processed/watersurfaces_hab/watersurfaces_hab.gpkg"), layer = "watersurfaces_hab_polygons", driver = "GPKG")
 
-con = dbConnect(SQLite(),
+con = dbConnect(RSQLite::SQLite(),
                 dbname = file.path(path, "20_processed/watersurfaces_hab/watersurfaces_hab.gpkg"))
 
 dbWriteTable(con, "watersurfaces_hab_types", watersurfaces_hab_types)

--- a/src/generate_watersurfaces_hab/index.Rmd
+++ b/src/generate_watersurfaces_hab/index.Rmd
@@ -47,7 +47,7 @@ library(n2khab)
 library(git2rdata)
 library(googlesheets)
 library(kableExtra)
-library(RSQLite)
+library(DBI)
 #devtools::install_github("inbo/inborutils", ref = "sessioninfo")
 library(inborutils)
 


### PR DESCRIPTION
According to [RSQLite's vignette](https://rsqlite.r-dbi.org/articles/rsqlite), `DBI::dbConnect()` must be used, not `RSQLite::dbConnect()`. This is updated here for existing `RSQLite::dbConnect()` implementations, i.e. in the bookdown projects of `habitatmap_stdized`, `habitatmap_terr` and `watersurfaces_hab`.