### PR TITLE
generate_habitatmap_stdized: use the copy of old MHQ gsheet

### DIFF
--- a/src/generate_habitatmap_stdized/10_generate_habmap_stdized.Rmd
+++ b/src/generate_habitatmap_stdized/10_generate_habmap_stdized.Rmd
@@ -23,7 +23,7 @@ straightforward. Table \@ref(tab:code_corrected) shows the corrected codes.
 
 ```{r, eval = FALSE}
 
-habmap_correction <-  gs_key("1Lltpq1_OQENZKrCmfDLuBiaZQ0_YCoGkFAqcOtFRdHg") %>%
+habmap_correction <-  gs_key("1PU9MDyJKZz2DOrKqb-SIIVmSaR1mh4Ke6v0WCqhr8t4") %>%
   gs_read(ws = 3)
 
 write_vc(habmap_correction,  "habmap_correction/habmap_correction",


### PR DESCRIPTION
This is the same fix as in https://github.com/inbo/n2khab/commit/eb11638.

The old MHQ sheet had got lost somehow, but I could restore a copy.