### PR TITLE
Generate watercourse_100mseg.gpkg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ src/private_code.R
 *.qgs
 *.bak
 *.qgz
+grass_*/
+watercourse_segments/

--- a/src/generate_watercourse_100mseg/.Rprofile
+++ b/src/generate_watercourse_100mseg/.Rprofile
@@ -1,0 +1,1 @@
+source("renv/activate.R")

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -210,7 +210,7 @@ execGRASS("v.to.points",
 We already took care of standardized column names within GRASS; so no further changes are needed when exporting the data from GRASS.
 We do it this way in order to minimize the number of times the data need to be written forth and back to a geopackage, which takes extra time (> 250e3 features) and file organization.
 
-```{r}
+```{r eval=params$grass_reexport}
 execGRASS("v.out.ogr",
           flags = "overwrite",
           input = "watercourse_100mseg",
@@ -219,7 +219,7 @@ execGRASS("v.out.ogr",
           output_layer = "watercourse_100mseg_lines")
 ```
 
-```{r}
+```{r eval=params$grass_reexport}
 # This export takes a very long time (> 60 min).
 # There must be some bug in the export procedure 
 # (after all, the data are simpler than previous one).

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -10,6 +10,8 @@ Further we will also derive a second layer which represent the _endpoints_ of th
 ```{r}
 local_root <- find_root(has_file("generate_watercourse_100mseg.Rproj"))
 datapath <- file.path(local_root, "data")
+n2khab_datapath <- find_root_file("n2khab_data",
+                                  criterion = has_dir("n2khab_data"))
 if (!dir.exists(datapath)) dir.create(datapath)
 finalpath <- find_root_file("n2khab_data/20_processed/watercourse_100mseg", 
                             criterion = has_dir("n2khab_data"))
@@ -32,7 +34,7 @@ if (.Platform$OS.type == "unix") {
 Read the `watercourses` data source (this step still needs reproducibility).
 
 ```{r paged.print=FALSE}
-watercourses <- read_sf(file.path(datapath, "watercourses"))
+watercourses <- read_sf(file.path(n2khab_datapath, "10_raw/watercourses"))
 ```
 
 Initialize GRASS projectfolder if non-existant, or link to the already existing one:
@@ -66,7 +68,7 @@ Add `watercourses` data source to GRASS database:
 
 ```{r eval=!grassdbase_exists}
 execGRASS("v.in.ogr",
-          input = file.path(datapath, "watercourses"),
+          input = file.path(n2khab_datapath, "10_raw/watercourses"),
           output = "watercourses")
 ```
 

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -2,8 +2,8 @@
 
 We will create a master dataset of watercourse segments of 100 m (`watercourse_100mseg`), in order to derive sampling frames of lotic types (3260 in particular).
 
-It is a processed data source, derived from the raw data source `watercourse_segments`.
-The segments have a 100 m length, except at the end of the linestrings in `watercourse_segments`.
+It is a processed data source, derived from the raw data source `watercourse_segments` (version `watercourse_segments_20180601`).
+The segments will have a 100 m length, except at the end of the linestrings of `watercourse_segments`.
 
 Further we derive a second data source `watercourse_100msegpoints` which represent the endpoints of the 100 m segments.
 
@@ -49,8 +49,10 @@ initGRASS(gisBase = link2GI::findGRASS()[1, 1],
 
 
 ```{r eval=!grass_exists}
+# setting CRS and extent of the GRASS location, based on 'watercourse_segments'
 execGRASS("g.proj", flags = c("c", "quiet"), 
           georef = file.path(datapath, "watercourse_segments"))
+  # note: setting the extent should only affect raster computations (so we don't need it)
 b_box <- st_bbox(watercourse_segments)
 execGRASS("g.region", flags = c("quiet"), 
           n = as.character(b_box["ymax"]), s = as.character(b_box["ymin"]), 
@@ -72,6 +74,8 @@ execGRASS("v.in.ogr",
 ```
 
 ### Generate `watercourse_100mseg` in GRASS
+
+To do this, we use the `v.split` command.
 
 <!-- g.manual v.split -->
 
@@ -133,6 +137,8 @@ system('v.category input=watercourse_100mseg_pre1 option=add layer=2 output=wate
 <!-- layer <2/watercourse_100mseg_2> table <watercourse_100mseg_2> in database <(...)/n2khab-preprocessing/src/generate_watercourse_100mseg/data/grass_watercourses/PERMANENT/sqlite/sqlite.db> through driver <sqlite> with key <cat> -->
 
 ### Generate `watercourse_100msegpoints` in GRASS
+
+To do this, we use the `v.to.points` command.
 
 <!-- g.manual v.to.points -->
 

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -32,7 +32,7 @@ if (.Platform$OS.type == "unix") {
 
 ## Geoprocessing steps in GRASS
 
-Read the `watercourse_segments` data source (this needs improvement).
+Read the `watercourse_segments` data source (this step still needs reproducibility).
 
 ```{r eval=!grass_exists, paged.print=FALSE}
 watercourse_segments <- read_sf(file.path(datapath, "watercourse_segments"))
@@ -63,7 +63,7 @@ execGRASS("g.region", flags = c("quiet"),
 use_sf()
 ```
 
-Add `watercourse_segments` data source to GRASS:
+Add `watercourse_segments` data source to GRASS database:
 
 ```{r eval=!grass_exists}
 execGRASS("v.in.ogr",
@@ -72,6 +72,8 @@ execGRASS("v.in.ogr",
 ```
 
 ### Generate `watercourse_100mseg` in GRASS
+
+<!-- g.manual v.split -->
 
 ```{r eval=!grass_exists}
 execGRASS("v.split",
@@ -131,6 +133,8 @@ system('v.category input=watercourse_100mseg_pre1 option=add layer=2 output=wate
 <!-- layer <2/watercourse_100mseg_2> table <watercourse_100mseg_2> in database <(...)/n2khab-preprocessing/src/generate_watercourse_100mseg/data/grass_watercourses/PERMANENT/sqlite/sqlite.db> through driver <sqlite> with key <cat> -->
 
 ### Generate `watercourse_100msegpoints` in GRASS
+
+<!-- g.manual v.to.points -->
 
 ```{r eval=!grass_exists}
 execGRASS("v.to.points",

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -91,8 +91,8 @@ execGRASS("v.split",
 system("v.category input=watercourse_100mseg_pre1 option=report")
 ```
 
-As seen from the above input, in accordance with the `v.split` manual, the categories and the attribute table of the original vector map are simply copied over.
-This means that the individual 100 m segments have no unique category, i.e. cannot have their own rows (with ID) in another attribute table.
+As seen from the above output, in accordance with the `v.split` manual, the categories and the attribute table of the original vector map are simply copied over.
+This means that the individual 100 m segments have no unique category, i.e. they don't have their own rows (with ID) in another attribute table.
 To get that, as explained in the documentation, we define a second layer^[To do that, the vector map `watercourse_100mseg_pre1` is copied, including layers & the link to the same attribute table.] with a unique category per feature (100 m segment) and create a new attribute table that links to the new layer (an attribute table always has exactly 1 row for each category and uses 1 layer to take categories from).
 Next, we copy the category of layer 1 as a mere attribute into a second column in the new attribute table (which is linked to layer 2), in order to define the link between the grouped category `cat_group` (categories of `watercourses_segements`) and the unique category `cat`.
 

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -208,5 +208,19 @@ execGRASS("v.to.points",
 <!-- all       263871          1     263871 -->
 
 
+
+## Exporting resulting objects from GRASS
+
+
+
+## Further handling in R
+
+
+
+## Writing the result to disk
+
+
+
+
 # Checks on the data source
 

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -5,7 +5,7 @@ We will create a master dataset of watercourse segments of 100 m (`watercourse_1
 It is a processed data source, derived from the raw data source `watercourse_segments` (version `watercourse_segments_20180601`).
 The segments will have a 100 m length, except at the end of the linestrings of `watercourse_segments`.
 
-Further we derive a second data source `watercourse_100msegpoints` which represent the endpoints of the 100 m segments.
+Further we will also derive a second layer which represent the _endpoints_ of the 100 m segments.
 
 ```{r}
 local_root <- find_root(has_file("generate_watercourse_100mseg.Rproj"))
@@ -73,6 +73,8 @@ execGRASS("v.in.ogr",
 ### Generate `watercourse_100mseg` in GRASS
 
 To do this, we use the `v.split` command.
+It will take each linestring of the raw `watercourse_segments` data source and split it into segments of 100 m length.
+This generally results in one segment (for each original linestring) that is shorter than 100 m!
 
 <!-- g.manual v.split -->
 
@@ -135,6 +137,7 @@ system('v.category input=watercourse_100mseg_pre1 option=add layer=2 output=wate
 ### Generate `watercourse_100msegpoints` in GRASS
 
 To do this, we use the `v.to.points` command.
+We create one point per 100 m segment, notably the _endpoint_.
 
 <!-- g.manual v.to.points -->
 

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -2,7 +2,7 @@
 
 We will create a master dataset of watercourse segments of 100 m (`watercourse_100mseg`), in order to derive sampling frames of lotic types (3260 in particular).
 
-It is a processed data source, derived from the raw data source `watercourses` (version `watercourses_20180601`).
+It is a processed data source, derived from the raw data source `watercourses` (version `watercourses_20200807`).
 The segments will have a 100 m length, except at the end of the linestrings of `watercourses`.
 
 Further we will also derive a second layer which represent the _endpoints_ of the 100 m segments.

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -88,18 +88,17 @@ execGRASS("v.in.ogr",
 
 ### Generate `watercourse_100mseg` in GRASS
 
-To do this, we use the `v.split` command.
+To do this, we first use the `v.edit` command to flip the direction of the linestrings, because the segments are to be generated from mouth to source, leaving segments of <100 m only at the source side.
+After that, we will use the `v.split` command.
 It will take each linestring of the raw `watercourses` data source and split it into segments of 100 m length.
 This generally results in one segment (for each original linestring) that is shorter than 100 m!
 
 <!-- g.manual v.split -->
 
 ```{r eval=!grassdbase_exists}
-execGRASS("v.split",
-          flags = c("f", "overwrite"),
-          input = "watercourses",
-          output = "watercourse_100mseg_pre1",
-          length = 100)
+execshell("g.copy vector=watercourses,watercourses_original")
+execshell("v.edit map=watercourses tool=flip where='1=1'")
+execshell("v.split -f --overwrite input=watercourses output=watercourse_100mseg_pre1 length=100")
 ```
 
 ```{r}
@@ -111,9 +110,6 @@ This means that the individual 100 m segments have no unique category, i.e. they
 To get that, as explained in the documentation, we define a second layer^[To do that, the vector map `watercourse_100mseg_pre1` is copied, including layers & the link to the same attribute table.] with a unique category per feature (100 m segment) and create a new attribute table that links to the new layer (an attribute table always has exactly 1 row for each category and uses 1 layer to take categories from).
 Next, we copy the category of layer 1 as a mere attribute into a second column in the new attribute table (which is linked to layer 2), in order to define the link between the grouped category `cat_group` (categories of `watercourses`) and the unique category `cat`.
 
-In order to execute the below three GRASS commands (not the outcommented ones), it may be necessary to break them down into separate `execGRASS()` statements.^[
-This depends on the availability of the GRASS executables in the shell PATH, which should have been set by `initGRASS()`.
-]
 The `execshell()` command directly sends the below commands to the shell as one script for execution by GRASS.
 
 ```{r eval=!grassdbase_exists}
@@ -138,10 +134,10 @@ execshell('v.category input=watercourse_100mseg_pre1 option=add layer=2 output=w
 <!--  100% -->
 <!-- Updating database... -->
 <!--  100% -->
-<!-- 263871 categories read from vector map (layer 2) -->
-<!-- 263871 records selected from table (layer 1) -->
-<!-- 263871 categories read from vector map exist in selection from table -->
-<!-- 263871 records updated/inserted (layer 2) -->
+<!-- 271676 categories read from vector map (layer 2) -->
+<!-- 271676 records selected from table (layer 1) -->
+<!-- 271676 categories read from vector map exist in selection from table -->
+<!-- 271676 records updated/inserted (layer 2) -->
 
 
 
@@ -153,7 +149,9 @@ execshell('v.category input=watercourse_100mseg_pre1 option=add layer=2 output=w
 ### Generate `watercourse_100msegpoints` in GRASS
 
 To do this, we use the `v.to.points` command.
-We create one point per 100 m segment, notably the _endpoint_.
+We want each point at the downstream side of its corresponding segment.
+We create one point per 100 m segment.
+As we flipped the direction of the watercourse lines, we want the _startpoint_ of each segment.
 
 <!-- g.manual v.to.points -->
 
@@ -163,66 +161,77 @@ execGRASS("v.to.points",
           input = "watercourse_100mseg",
           layer = "2",
           output = "watercourse_100msegpoints",
-          use = "end")
+          use = "start")
 ```
 
+<!--  100% -->
+<!-- Building topology for vector map <watercourse_100msegpoints@PERMANENT>... -->
+<!-- Registering primitives... -->
+<!--     270000 -->
+<!-- v.to.points complete. 271676 points written to output vector map. -->
+
+
 <!-- v.info watercourse_100msegpoints layer=1 -->
-<!--  +----------------------------------------------------------------------------+ -->
-<!--  | Name:            watercourse_100msegpoints                                 | -->
-<!--  | Mapset:          PERMANENT                                                 | -->
-<!--  | Location:        grass_watercourses                                        | -->
-<!--  | Database:        (...)                                                     | -->
-<!--  | Title:                                                                     | -->
-<!--  | Map scale:       1:1                                                       | -->
-<!--  | Name of creator: floris                                                    | -->
-<!--  | Organization:                                                              | -->
-<!--  | Source date:     Fri Nov 27 16:14:43 2020                                  | -->
-<!--  | Timestamp (first layer): none                                              | -->
-<!--  |----------------------------------------------------------------------------| -->
-<!--  | Map format:      native                                                    | -->
-<!--  |----------------------------------------------------------------------------| -->
-<!--  |   Type of map: vector (level: 2)                                           | -->
-<!--  |                                                                            | -->
-<!--  |   Number of points:       263871          Number of centroids:  0          | -->
-<!--  |   Number of lines:        0               Number of boundaries: 0          | -->
-<!--  |   Number of areas:        0               Number of islands:    0          | -->
-<!--  |                                                                            | -->
-<!--  |   Map is 3D:              No                                               | -->
-<!--  |   Number of dblinks:      2                                                | -->
-<!--  |                                                                            | -->
-<!--  |   Projection: Belge 1972 / Belgian Lambert 72                              | -->
-<!--  |                                                                            | -->
-<!--  |               N:       244044.9074    S:   153062.38093558                 | -->
-<!--  |               E:       258444.2968    W:    23006.85298789                 | -->
-<!--  |                                                                            | -->
-<!--  |   Digitization threshold: 0                                                | -->
-<!--  |   Comment:                                                                 | -->
-<!--  |                                                                            | -->
-<!--  +----------------------------------------------------------------------------+ -->
+ <!-- +----------------------------------------------------------------------------+ -->
+ <!-- | Name:            watercourse_100msegpoints                                 | -->
+ <!-- | Mapset:          PERMANENT                                                 | -->
+ <!-- | Location:        grass_watercourses                                        | -->
+ <!-- | Database:        /media/floris/DATA/PROJECTS/09685_NatuurlijkMilieu/160 Be | -->
+ <!-- | Title:                                                                     | -->
+ <!-- | Map scale:       1:1                                                       | -->
+ <!-- | Name of creator: floris                                                    | -->
+ <!-- | Organization:                                                              | -->
+ <!-- | Source date:     Wed Dec 16 16:54:35 2020                                  | -->
+ <!-- | Timestamp (first layer): none                                              | -->
+ <!-- |----------------------------------------------------------------------------| -->
+ <!-- | Map format:      native                                                    | -->
+ <!-- |----------------------------------------------------------------------------| -->
+ <!-- |   Type of map: vector (level: 2)                                           | -->
+ <!-- |                                                                            | -->
+ <!-- |   Number of points:       271676          Number of centroids:  0          | -->
+ <!-- |   Number of lines:        0               Number of boundaries: 0          | -->
+ <!-- |   Number of areas:        0               Number of islands:    0          | -->
+ <!-- |                                                                            | -->
+ <!-- |   Map is 3D:              No                                               | -->
+ <!-- |   Number of dblinks:      2                                                | -->
+ <!-- |                                                                            | -->
+ <!-- |   Projection: Belge 1972 / Belgian Lambert 72                              | -->
+ <!-- |                                                                            | -->
+ <!-- |               N:       243962.6791    S:   153064.35460326                 | -->
+ <!-- |               E:   258447.81310536    W:    22979.76203745                 | -->
+ <!-- |                                                                            | -->
+ <!-- |   Digitization threshold: 0                                                | -->
+ <!-- |   Comment:                                                                 | -->
+ <!-- |                                                                            | -->
+ <!-- +----------------------------------------------------------------------------+ -->
+
 
 <!-- v.category input=watercourse_100msegpoints option=report -->
 <!-- Layer/table: 1/watercourse_100msegpoints_1 -->
 <!-- type       count        min        max -->
-<!-- point     263871          1     263871 -->
+<!-- point     271676          1     271676 -->
 <!-- line           0          0          0 -->
 <!-- boundary       0          0          0 -->
 <!-- centroid       0          0          0 -->
 <!-- area           0          0          0 -->
 <!-- face           0          0          0 -->
 <!-- kernel         0          0          0 -->
-<!-- all       263871          1     263871 -->
+<!-- all       271676          1     271676 -->
 <!-- Layer/table: 2/watercourse_100msegpoints_2 -->
 <!-- type       count        min        max -->
-<!-- point     263871          1     263871 -->
+<!-- point     271676          1     271676 -->
 <!-- line           0          0          0 -->
 <!-- boundary       0          0          0 -->
 <!-- centroid       0          0          0 -->
 <!-- area           0          0          0 -->
 <!-- face           0          0          0 -->
 <!-- kernel         0          0          0 -->
-<!-- all       263871          1     263871 -->
+<!-- all       271676          1     271676 -->
 
-
+<!-- v.info -c watercourse_100msegpoints layer=1 -->
+<!-- Displaying column types/names for database connection of layer <1>: -->
+<!-- INTEGER|rank -->
+<!-- INTEGER|vhag_code -->
 
 ## Exporting resulting objects from GRASS
 

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -243,6 +243,7 @@ execGRASS("v.out.ogr",
 # There must be some bug in the export procedure 
 # (after all, the data are simpler than previous one).
 execGRASS("v.out.ogr",
+          "a",
           input = "watercourse_100msegpoints",
           layer = "1",
           output = file.path(finalpath, "watercourse_100mseg.gpkg"),

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -322,7 +322,7 @@ seg %>%
   ggplot() +
   geom_sf(colour = "grey50") +
   geom_sf(data = pts %>% filter(rank < 2e4), colour = "red", size = 0.5) +
-  lims(x = c(198e3, 204e3), y = c(183e3, 188e3)) +
+  lims(x = c(36e3, 40e3), y = c(184e3, 188e3)) +
   coord_sf(datum = 31370) +
   theme_bw()+
   theme(panel.grid = element_blank())

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -291,19 +291,15 @@ file(filepath) %>%
   `names<-`("sha256sum")
 ```
 
-We best set the crs explicitly: while the WKT from the gpkg (exported from GRASS using GDAL/OGR) is correct (parameters identical to the ones of `watercourses`), it lost a few names and would otherwise be displayed as 'unknown'.
 
 ```{r paged.print=FALSE, warning=FALSE}
 (seg <- read_sf(filepath, 
-                layer = "watercourse_100mseg_lines",
-                crs = 31370)
-)
+                layer = "watercourse_100mseg_lines"))
 ```
 
 ```{r paged.print=FALSE, warning=FALSE}
 (pts <- read_sf(filepath, 
-                layer = "watercourse_100mseg_points",
-                crs = 31370))
+                layer = "watercourse_100mseg_points"))
 ```
 
 ```{r}

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -38,13 +38,17 @@ Read the `watercourse_segments` data source (this needs improvement).
 watercourse_segments <- read_sf(file.path(datapath, "watercourse_segments"))
 ```
 
-Initialize GRASS project if non-existant:
+Initialize GRASS projectfolder if non-existant, or link to the already existing one:
 
-```{r eval=!grass_exists}
+```{r}
 initGRASS(gisBase = link2GI::findGRASS()[1, 1],
           home = tempdir(),
           gisDbase = datapath, location = "grass_watercourses", 
           mapset = "PERMANENT", override = TRUE)
+```
+
+
+```{r eval=!grass_exists}
 execGRASS("g.proj", flags = c("c", "quiet"), 
           georef = file.path(datapath, "watercourse_segments"))
 b_box <- st_bbox(watercourse_segments)
@@ -52,6 +56,10 @@ execGRASS("g.region", flags = c("quiet"),
           n = as.character(b_box["ymax"]), s = as.character(b_box["ymin"]), 
           e = as.character(b_box["xmax"]), w = as.character(b_box["xmin"]), 
           res = "1")
+```
+
+
+```{r}
 use_sf()
 ```
 

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -11,12 +11,9 @@ Further we derive a second data source `watercourse_100msegpoints` which represe
 local_root <- find_root(has_file("generate_watercourse_100mseg.Rproj"))
 datapath <- file.path(local_root, "data")
 if (!dir.exists(datapath)) dir.create(datapath)
-finalpath_segments <- find_root_file("n2khab_data/20_processed/watercourse_100mseg", 
-                                     criterion = has_dir("n2khab_data"))
-if (!dir.exists(finalpath_segments)) dir.create(finalpath_segments)
-finalpath_segmentpoints <- find_root_file("n2khab_data/20_processed/watercourse_100msegpoints", 
-                                          criterion = has_dir("n2khab_data"))
-if (!dir.exists(finalpath_segmentpoints)) dir.create(finalpath_segmentpoints)
+finalpath <- find_root_file("n2khab_data/20_processed/watercourse_100mseg", 
+                            criterion = has_dir("n2khab_data"))
+if (!dir.exists(finalpath)) dir.create(finalpath)
 ```
 
 ```{r}
@@ -210,13 +207,32 @@ execGRASS("v.to.points",
 
 ## Exporting resulting objects from GRASS
 
+We already took care of standardized column names within GRASS; so no further changes are needed when exporting the data from GRASS.
+We do it this way in order to minimize the number of times the data need to be written forth and back to a geopackage, which takes extra time (> 250e3 features) and file organization.
+
+```{r}
+execGRASS("v.out.ogr",
+          flags = "overwrite",
+          input = "watercourse_100mseg",
+          layer = "2",
+          output = file.path(finalpath, "watercourse_100mseg.gpkg"),
+          output_layer = "watercourse_100mseg_lines")
+```
+
+```{r}
+# This export takes a very long time (> 60 min).
+# There must be some bug in the export procedure 
+# (after all, the data are simpler than previous one).
+execGRASS("v.out.ogr",
+          input = "watercourse_100msegpoints",
+          layer = "1",
+          output = file.path(finalpath, "watercourse_100mseg.gpkg"),
+          output_layer = "watercourse_100mseg_points")
+```
 
 
-## Further handling in R
 
-
-
-## Writing the result to disk
+# Checks on the data source
 
 
 

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -31,7 +31,7 @@ if (.Platform$OS.type == "unix") {
 
 Read the `watercourse_segments` data source (this step still needs reproducibility).
 
-```{r eval=!grassdbase_exists, paged.print=FALSE}
+```{r paged.print=FALSE}
 watercourse_segments <- read_sf(file.path(datapath, "watercourse_segments"))
 ```
 
@@ -234,8 +234,47 @@ execGRASS("v.out.ogr",
 
 # Checks on the data source
 
+We best set the crs explicitly: while the WKT from the gpkg (exported from GRASS using GDAL/OGR) is correct (parameters identical to the ones of `watercourse_segments`), it lost a few names and would otherwise be displayed as 'unknown'.
 
+```{r paged.print=FALSE, warning=FALSE}
+(seg <- read_sf(file.path(finalpath, 
+                          "watercourse_100mseg.gpkg"), 
+                layer = "watercourse_100mseg_lines",
+                crs = 31370)
+)
+```
 
+```{r paged.print=FALSE, warning=FALSE}
+(pts <- read_sf(file.path(finalpath, 
+                          "watercourse_100mseg.gpkg"), 
+                layer = "watercourse_100mseg_points",
+                crs = 31370))
+```
 
-# Checks on the data source
+```{r}
+all.equal(seg$rank, pts$rank)
+```
+
+```{r}
+all.equal(seg$vhas_code, pts$vhas_code)
+```
+
+```{r}
+all.equal(unique(seg$vhas_code), unique(watercourse_segments$VHAS))
+```
+
+Cartographic display of a row selection:
+
+```{r}
+seg %>% 
+  filter(rank < 2e4) %>% 
+  ggplot() +
+  geom_sf(colour = "grey50") +
+  geom_sf(data = pts %>% filter(rank < 2e4), colour = "red", size = 0.5) +
+  lims(x = c(198e3, 204e3), y = c(183e3, 188e3)) +
+  coord_sf(datum = 31370) +
+  theme_bw()+
+  theme(panel.grid = element_blank())
+```
+
 

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -52,6 +52,19 @@ initGRASS(gisBase = if (interactive()) gisbase_grass else params$gisbase_grass,
           mapset = "PERMANENT", override = TRUE)
 ```
 
+Cross-platform function to pass full GRASS command syntax as a string from R:
+
+```{r}
+execshell <- function(commandstring, intern = FALSE) {
+  if (.Platform$OS.type == "windows") {
+    res <- shell(commandstring, intern = TRUE)
+  } else {
+    res <- system(commandstring, intern = TRUE)
+  }
+  if (!intern) cat(res, sep = "\n") else return(res)
+}
+```
+
 
 ```{r eval=!grassdbase_exists}
 # setting CRS and extent of the GRASS location, based on 'watercourses'
@@ -90,7 +103,7 @@ execGRASS("v.split",
 ```
 
 ```{r}
-system("v.category input=watercourse_100mseg_pre1 option=report")
+execshell("v.category input=watercourse_100mseg_pre1 option=report")
 ```
 
 As seen from the above output, in accordance with the `v.split` manual, the categories and the attribute table of the original vector map are simply copied over.
@@ -101,10 +114,10 @@ Next, we copy the category of layer 1 as a mere attribute into a second column i
 In order to execute the below three GRASS commands (not the outcommented ones), it may be necessary to break them down into separate `execGRASS()` statements.^[
 This depends on the availability of the GRASS executables in the shell PATH, which should have been set by `initGRASS()`.
 ]
-The `system()` command directly sends the below commands to the shell as one script for execution by GRASS.
+The `execshell()` command directly sends the below commands to the shell as one script for execution by GRASS.
 
 ```{r eval=!grassdbase_exists}
-system('v.category input=watercourse_100mseg_pre1 option=add layer=2 output=watercourse_100mseg
+execshell('v.category input=watercourse_100mseg_pre1 option=add layer=2 output=watercourse_100mseg
        # v.category input=watercourse_100mseg option=report
        # v.db.connect -p map=watercourse_100mseg
        v.db.addtable watercourse_100mseg layer=2 key="rank" columns="vhag_code int"

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -1,11 +1,11 @@
 # Making the data source
 
-We will create a master dataset of watercourse segments (`watercourse_100mseg`), in order to derive sampling frames of lotic types (3260 in particular).
+We will create a master dataset of watercourse segments of 100 m (`watercourse_100mseg`), in order to derive sampling frames of lotic types (3260 in particular).
 
 It is a processed data source, derived from the raw data source `watercourse_segments`.
 The segments have a 100 m length, except at the end of the linestrings in `watercourse_segments`.
 
-Further we derive a second data source `watercourse_100msegpoints` which represent the endpoints of the segments.
+Further we derive a second data source `watercourse_100msegpoints` which represent the endpoints of the 100 m segments.
 
 ```{r}
 local_root <- find_root(has_file("generate_watercourse_100mseg.Rproj"))
@@ -20,7 +20,7 @@ if (!dir.exists(finalpath_segmentpoints)) dir.create(finalpath_segmentpoints)
 ```
 
 ```{r}
-grass_location <- file.path(datapath, "grass_watercourse_segments")
+grass_location <- file.path(datapath, "grass_watercourses")
 if (!dir.exists(grass_location)) dir.create(file.path(grass_location, "PERMANENT"),
                                             recursive = TRUE)
 grass_exists <- file.exists(file.path(grass_location, "PERMANENT/PROJ_INFO"))
@@ -32,18 +32,18 @@ if (.Platform$OS.type == "unix") {
 
 ## Geoprocessing steps in GRASS
 
-<!-- Read the `watercourse_segments` data source (this needs improvement). -->
+Read the `watercourse_segments` data source (this needs improvement).
 
-<!-- ```{r paged.print=FALSE} -->
-<!-- watercourse_segments <- read_sf("data/watercourse_segments") -->
-<!-- ``` -->
+```{r eval=!grass_exists, paged.print=FALSE}
+watercourse_segments <- read_sf(file.path(datapath, "watercourse_segments"))
+```
 
 Initialize GRASS project if non-existant:
 
 ```{r eval=!grass_exists}
 initGRASS(gisBase = link2GI::findGRASS()[1, 1],
           home = tempdir(),
-          gisDbase = datapath, location = grass_location, 
+          gisDbase = datapath, location = "grass_watercourses", 
           mapset = "PERMANENT", override = TRUE)
 execGRASS("g.proj", flags = c("c", "quiet"), 
           georef = file.path(datapath, "watercourse_segments"))

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -1,0 +1,93 @@
+# Making the data source
+
+We will create a master dataset of watercourse segments (`watercourse_100mseg`), in order to derive sampling frames of lotic types (3260 in particular).
+
+It is a processed data source, derived from the raw data source `watercourse_segments`.
+The segments have a 100 m length, except at the end of the linestrings in `watercourse_segments`.
+
+Further we derive a second data source `watercourse_100msegpoints` which represent the endpoints of the segments.
+
+```{r}
+local_root <- find_root(has_file("generate_watercourse_100mseg.Rproj"))
+datapath <- file.path(local_root, "data")
+if (!dir.exists(datapath)) dir.create(datapath)
+finalpath_segments <- find_root_file("n2khab_data/20_processed/watercourse_100mseg", 
+                                     criterion = has_dir("n2khab_data"))
+if (!dir.exists(finalpath_segments)) dir.create(finalpath_segments)
+finalpath_segmentpoints <- find_root_file("n2khab_data/20_processed/watercourse_100msegpoints", 
+                                          criterion = has_dir("n2khab_data"))
+if (!dir.exists(finalpath_segmentpoints)) dir.create(finalpath_segmentpoints)
+```
+
+```{r}
+grass_location <- file.path(datapath, "grass_watercourse_segments")
+if (!dir.exists(grass_location)) dir.create(file.path(grass_location, "PERMANENT"),
+                                            recursive = TRUE)
+grass_exists <- file.exists(file.path(grass_location, "PERMANENT/PROJ_INFO"))
+if (.Platform$OS.type == "unix") {
+  Sys.setenv(GRASS_PYTHON = system("which python3", intern = TRUE))
+}
+```
+
+
+## Geoprocessing steps in GRASS
+
+<!-- Read the `watercourse_segments` data source (this needs improvement). -->
+
+<!-- ```{r paged.print=FALSE} -->
+<!-- watercourse_segments <- read_sf("data/watercourse_segments") -->
+<!-- ``` -->
+
+Initialize GRASS project if non-existant:
+
+```{r eval=!grass_exists}
+initGRASS(gisBase = link2GI::findGRASS()[1, 1],
+          home = tempdir(),
+          gisDbase = datapath, location = grass_location, 
+          mapset = "PERMANENT", override = TRUE)
+execGRASS("g.proj", flags = c("c", "quiet"), 
+          georef = file.path(datapath, "watercourse_segments"))
+b_box <- st_bbox(watercourse_segments)
+execGRASS("g.region", flags = c("quiet"), 
+          n = as.character(b_box["ymax"]), s = as.character(b_box["ymin"]), 
+          e = as.character(b_box["xmax"]), w = as.character(b_box["xmin"]), 
+          res = "1")
+use_sf()
+```
+
+Add `watercourse_segments` data source to GRASS:
+
+```{r eval=!grass_exists}
+execGRASS("v.in.ogr",
+          input = file.path(datapath, "watercourse_segments"),
+          output = "watercourse_segments")
+```
+
+### Generate `watercourse_100mseg` in GRASS
+
+```{r eval=!grass_exists}
+execGRASS("v.split",
+          flags = c("f", "overwrite"),
+          input = "watercourse_segments",
+          output = "watercourse_100mseg",
+          length = 100)
+```
+
+```{r eval=!grass_exists}
+system("v.category input=watercourse_100mseg option=report")
+```
+
+
+
+### Generate `watercourse_100msegpoints` in GRASS
+
+```{r eval=!grass_exists}
+execGRASS("v.to.points",
+          flags = c("overwrite"),
+          input = "watercourse_100mseg",
+          output = "watercourse_100msegpoints",
+          use = "end")
+```
+
+# Checks on the data source
+

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -2,8 +2,8 @@
 
 We will create a master dataset of watercourse segments of 100 m (`watercourse_100mseg`), in order to derive sampling frames of lotic types (3260 in particular).
 
-It is a processed data source, derived from the raw data source `watercourse_segments` (version `watercourse_segments_20180601`).
-The segments will have a 100 m length, except at the end of the linestrings of `watercourse_segments`.
+It is a processed data source, derived from the raw data source `watercourses` (version `watercourses_20180601`).
+The segments will have a 100 m length, except at the end of the linestrings of `watercourses`.
 
 Further we will also derive a second layer which represent the _endpoints_ of the 100 m segments.
 
@@ -29,10 +29,10 @@ if (.Platform$OS.type == "unix") {
 
 ## Geoprocessing steps in GRASS
 
-Read the `watercourse_segments` data source (this step still needs reproducibility).
+Read the `watercourses` data source (this step still needs reproducibility).
 
 ```{r paged.print=FALSE}
-watercourse_segments <- read_sf(file.path(datapath, "watercourse_segments"))
+watercourses <- read_sf(file.path(datapath, "watercourses"))
 ```
 
 Initialize GRASS projectfolder if non-existant, or link to the already existing one:
@@ -46,11 +46,11 @@ initGRASS(gisBase = link2GI::findGRASS()[1, 1],
 
 
 ```{r eval=!grassdbase_exists}
-# setting CRS and extent of the GRASS location, based on 'watercourse_segments'
+# setting CRS and extent of the GRASS location, based on 'watercourses'
 execGRASS("g.proj", flags = c("c", "quiet"), 
-          georef = file.path(datapath, "watercourse_segments"))
+          georef = file.path(datapath, "watercourses"))
   # note: setting the extent should only affect raster computations (so we don't need it)
-b_box <- st_bbox(watercourse_segments)
+b_box <- st_bbox(watercourses)
 execGRASS("g.region", flags = c("quiet"), 
           n = as.character(b_box["ymax"]), s = as.character(b_box["ymin"]), 
           e = as.character(b_box["xmax"]), w = as.character(b_box["xmin"]), 
@@ -62,18 +62,18 @@ execGRASS("g.region", flags = c("quiet"),
 use_sf()
 ```
 
-Add `watercourse_segments` data source to GRASS database:
+Add `watercourses` data source to GRASS database:
 
 ```{r eval=!grassdbase_exists}
 execGRASS("v.in.ogr",
-          input = file.path(datapath, "watercourse_segments"),
-          output = "watercourse_segments")
+          input = file.path(datapath, "watercourses"),
+          output = "watercourses")
 ```
 
 ### Generate `watercourse_100mseg` in GRASS
 
 To do this, we use the `v.split` command.
-It will take each linestring of the raw `watercourse_segments` data source and split it into segments of 100 m length.
+It will take each linestring of the raw `watercourses` data source and split it into segments of 100 m length.
 This generally results in one segment (for each original linestring) that is shorter than 100 m!
 
 <!-- g.manual v.split -->
@@ -81,7 +81,7 @@ This generally results in one segment (for each original linestring) that is sho
 ```{r eval=!grassdbase_exists}
 execGRASS("v.split",
           flags = c("f", "overwrite"),
-          input = "watercourse_segments",
+          input = "watercourses",
           output = "watercourse_100mseg_pre1",
           length = 100)
 ```
@@ -104,18 +104,18 @@ The `system()` command directly sends the below commands to the shell as one scr
 system('v.category input=watercourse_100mseg_pre1 option=add layer=2 output=watercourse_100mseg
        # v.category input=watercourse_100mseg option=report
        # v.db.connect -p map=watercourse_100mseg
-       v.db.addtable watercourse_100mseg layer=2 key="rank" columns="vhas_code int"
+       v.db.addtable watercourse_100mseg layer=2 key="rank" columns="vhag_code int"
        # v.db.connect -p map=watercourse_100mseg
        # v.info -c watercourse_100mseg layer=2
        # v.info -c watercourse_100mseg layer=1
-       v.to.db map=watercourse_100mseg layer=2 option=query query_layer=1 query_column=VHAS columns=vhas_code --overwrite
+       v.to.db map=watercourse_100mseg layer=2 option=query query_layer=1 query_column=VHAG columns=vhag_code --overwrite
        # v.db.select map=watercourse_100mseg layer=2 | head
        ')
 ```
 
 <!-- Output from the v.to.db command: -->
 
-<!-- WARNING: Values in column <vhas_code> will be overwritten -->
+<!-- WARNING: Values in column <vhag_code> will be overwritten -->
 <!-- Reading features... -->
 <!--  100% -->
 <!-- Querying database... -->
@@ -131,7 +131,7 @@ system('v.category input=watercourse_100mseg_pre1 option=add layer=2 output=wate
 
 <!-- v.db.connect -p map=watercourse_100mseg -->
 <!-- Vector map <watercourse_100mseg> is connected by: -->
-<!-- layer <1/watercourse_segments> table <watercourse_100mseg> in database <(...)/n2khab-preprocessing/src/generate_watercourse_100mseg/data/grass_watercourses/PERMANENT/sqlite/sqlite.db> through driver <sqlite> with key <cat> -->
+<!-- layer <1/watercourses> table <watercourse_100mseg> in database <(...)/n2khab-preprocessing/src/generate_watercourse_100mseg/data/grass_watercourses/PERMANENT/sqlite/sqlite.db> through driver <sqlite> with key <cat> -->
 <!-- layer <2/watercourse_100mseg_2> table <watercourse_100mseg_2> in database <(...)/n2khab-preprocessing/src/generate_watercourse_100mseg/data/grass_watercourses/PERMANENT/sqlite/sqlite.db> through driver <sqlite> with key <rank> -->
 
 ### Generate `watercourse_100msegpoints` in GRASS
@@ -240,10 +240,10 @@ Both layers in the GPKG file have exactly the same attribute variables:
 
 - `rank`: a unique integer increment (1-2-3-4-5-...).
 It is to be used in a _relative_ way: it ranks the 100 m segments / points along each original linestring in the raw data source.
-- `vhas_code`: the unique VHAS code of the original linestring in the raw data source.
+- `vhag_code`: the unique VHAG code of the original linestring in the raw data source.
 It is common to all segments / points in the processed data source that belong to the same original watercourse segment.
 
-To obtain other attributes, one can make a join on the VHAS code column of the raw data source.
+To obtain other attributes, one can make a join on the VHAG code column of the raw data source.
 
 
 # Checks on the data source
@@ -265,7 +265,7 @@ file(filepath) %>%
   `names<-`("sha256sum")
 ```
 
-We best set the crs explicitly: while the WKT from the gpkg (exported from GRASS using GDAL/OGR) is correct (parameters identical to the ones of `watercourse_segments`), it lost a few names and would otherwise be displayed as 'unknown'.
+We best set the crs explicitly: while the WKT from the gpkg (exported from GRASS using GDAL/OGR) is correct (parameters identical to the ones of `watercourses`), it lost a few names and would otherwise be displayed as 'unknown'.
 
 ```{r paged.print=FALSE, warning=FALSE}
 (seg <- read_sf(filepath, 
@@ -285,11 +285,11 @@ all.equal(seg$rank, pts$rank)
 ```
 
 ```{r}
-all.equal(seg$vhas_code, pts$vhas_code)
+all.equal(seg$vhag_code, pts$vhag_code)
 ```
 
 ```{r}
-all.equal(unique(seg$vhas_code), unique(watercourse_segments$VHAS))
+all.equal(unique(seg$vhag_code), unique(watercourses$VHAG))
 ```
 
 Cartographic display of a row selection:

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -31,7 +31,7 @@ if (.Platform$OS.type == "unix") {
 
 ## Geoprocessing steps in GRASS
 
-Read the `watercourses` data source (this step still needs reproducibility).
+Read the `watercourses` data source.
 
 ```{r paged.print=FALSE}
 watercourses <- read_sf(file.path(n2khab_datapath, "10_raw/watercourses"))
@@ -109,7 +109,7 @@ execshell("v.category input=watercourse_100mseg_pre1 option=report")
 As seen from the above output, in accordance with the `v.split` manual, the categories and the attribute table of the original vector map are simply copied over.
 This means that the individual 100 m segments have no unique category, i.e. they don't have their own rows (with ID) in another attribute table.
 To get that, as explained in the documentation, we define a second layer^[To do that, the vector map `watercourse_100mseg_pre1` is copied, including layers & the link to the same attribute table.] with a unique category per feature (100 m segment) and create a new attribute table that links to the new layer (an attribute table always has exactly 1 row for each category and uses 1 layer to take categories from).
-Next, we copy the category of layer 1 as a mere attribute into a second column in the new attribute table (which is linked to layer 2), in order to define the link between the grouped category `cat_group` (categories of `watercourses_segements`) and the unique category `cat`.
+Next, we copy the category of layer 1 as a mere attribute into a second column in the new attribute table (which is linked to layer 2), in order to define the link between the grouped category `cat_group` (categories of `watercourses`) and the unique category `cat`.
 
 In order to execute the below three GRASS commands (not the outcommented ones), it may be necessary to break them down into separate `execGRASS()` statements.^[
 This depends on the availability of the GRASS executables in the shell PATH, which should have been set by `initGRASS()`.
@@ -258,7 +258,7 @@ Both layers in the GPKG file have exactly the same attribute variables:
 - `rank`: a unique integer increment (1-2-3-4-5-...).
 It is to be used in a _relative_ way: it ranks the 100 m segments / points along each original linestring in the raw data source.
 - `vhag_code`: the unique VHAG code of the original linestring in the raw data source.
-It is common to all segments / points in the processed data source that belong to the same original watercourse segment.
+It is common to all segments / points in the processed data source that belong to the same original watercourse.
 
 To obtain other attributes, one can make a join on the VHAG code column of the raw data source.
 

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -96,7 +96,7 @@ This means that the individual 100 m segments have no unique category, i.e. they
 To get that, as explained in the documentation, we define a second layer^[To do that, the vector map `watercourse_100mseg_pre1` is copied, including layers & the link to the same attribute table.] with a unique category per feature (100 m segment) and create a new attribute table that links to the new layer (an attribute table always has exactly 1 row for each category and uses 1 layer to take categories from).
 Next, we copy the category of layer 1 as a mere attribute into a second column in the new attribute table (which is linked to layer 2), in order to define the link between the grouped category `cat_group` (categories of `watercourses_segements`) and the unique category `cat`.
 
-In order to execute the below four GRASS commands (not the outcommented ones), it may be necessary to break them down into separate `execGRASS()` statements.^[
+In order to execute the below three GRASS commands (not the outcommented ones), it may be necessary to break them down into separate `execGRASS()` statements.^[
 This depends on the availability of the GRASS executables in the shell PATH, which should have been set by `initGRASS()`.
 ]
 The `system()` command directly sends the below commands to the shell as one script for execution by GRASS.
@@ -105,19 +105,18 @@ The `system()` command directly sends the below commands to the shell as one scr
 system('v.category input=watercourse_100mseg_pre1 option=add layer=2 output=watercourse_100mseg
        # v.category input=watercourse_100mseg option=report
        # v.db.connect -p map=watercourse_100mseg
-       v.db.addtable watercourse_100mseg layer=2
+       v.db.addtable watercourse_100mseg layer=2 key="rank" columns="vhas_code int"
        # v.db.connect -p map=watercourse_100mseg
        # v.info -c watercourse_100mseg layer=2
        # v.info -c watercourse_100mseg layer=1
-       v.db.addcolumn map=watercourse_100mseg layer=2 column="cat_group int"
-       v.to.db map=watercourse_100mseg layer=2 option=query query_layer=1 query_column=cat columns=cat_group --overwrite
+       v.to.db map=watercourse_100mseg layer=2 option=query query_layer=1 query_column=VHAS columns=vhas_code --overwrite
        # v.db.select map=watercourse_100mseg layer=2 | head
        ')
 ```
 
 <!-- Output from the v.to.db command: -->
 
-<!-- WARNING: Values in column <cat_group> will be overwritten -->
+<!-- WARNING: Values in column <vhas_code> will be overwritten -->
 <!-- Reading features... -->
 <!--  100% -->
 <!-- Querying database... -->
@@ -134,7 +133,7 @@ system('v.category input=watercourse_100mseg_pre1 option=add layer=2 output=wate
 <!-- v.db.connect -p map=watercourse_100mseg -->
 <!-- Vector map <watercourse_100mseg> is connected by: -->
 <!-- layer <1/watercourse_segments> table <watercourse_100mseg> in database <(...)/n2khab-preprocessing/src/generate_watercourse_100mseg/data/grass_watercourses/PERMANENT/sqlite/sqlite.db> through driver <sqlite> with key <cat> -->
-<!-- layer <2/watercourse_100mseg_2> table <watercourse_100mseg_2> in database <(...)/n2khab-preprocessing/src/generate_watercourse_100mseg/data/grass_watercourses/PERMANENT/sqlite/sqlite.db> through driver <sqlite> with key <cat> -->
+<!-- layer <2/watercourse_100mseg_2> table <watercourse_100mseg_2> in database <(...)/n2khab-preprocessing/src/generate_watercourse_100mseg/data/grass_watercourses/PERMANENT/sqlite/sqlite.db> through driver <sqlite> with key <rank> -->
 
 ### Generate `watercourse_100msegpoints` in GRASS
 

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -234,6 +234,17 @@ execGRASS("v.out.ogr",
 ```
 
 
+# Attribute variables of the processed data source: explanation
+
+Both layers in the GPKG file have exactly the same attribute variables:
+
+- `rank`: a unique integer increment (1-2-3-4-5-...).
+It is to be used in a _relative_ way: it ranks the 100 m segments / points along each original linestring in the raw data source.
+- `vhas_code`: the unique VHAS code of the original linestring in the raw data source.
+It is common to all segments / points in the processed data source that belong to the same original watercourse segment.
+
+To obtain other attributes, one can make a join on the VHAS code column of the raw data source.
+
 
 # Checks on the data source
 

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -40,7 +40,13 @@ watercourses <- read_sf(file.path(n2khab_datapath, "10_raw/watercourses"))
 Initialize GRASS projectfolder if non-existant, or link to the already existing one:
 
 ```{r}
-initGRASS(gisBase = link2GI::findGRASS()[1, 1],
+if (interactive()) {
+gisbase_grass <- 
+  if (.Platform$OS.type == "windows") link2GI::paramGRASSw()$gisbase_GRASS[1] else {
+    link2GI::paramGRASSx()$gisbase_GRASS[1]
+  }
+}
+initGRASS(gisBase = if (interactive()) gisbase_grass else params$gisbase_grass,
           home = tempdir(),
           gisDbase = datapath, location = "grass_watercourses", 
           mapset = "PERMANENT", override = TRUE)

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -234,19 +234,34 @@ execGRASS("v.out.ogr",
 
 # Checks on the data source
 
+```{r}
+filepath <- file.path(finalpath, "watercourse_100mseg.gpkg")
+```
+
+Checksums:
+
+```{r}
+file(filepath) %>% 
+  openssl::md5() %>% 
+  str_c(collapse = '') %>% 
+  `names<-`("md5sum")
+file(filepath) %>% 
+  openssl::sha256() %>% 
+  str_c(collapse = '') %>% 
+  `names<-`("sha256sum")
+```
+
 We best set the crs explicitly: while the WKT from the gpkg (exported from GRASS using GDAL/OGR) is correct (parameters identical to the ones of `watercourse_segments`), it lost a few names and would otherwise be displayed as 'unknown'.
 
 ```{r paged.print=FALSE, warning=FALSE}
-(seg <- read_sf(file.path(finalpath, 
-                          "watercourse_100mseg.gpkg"), 
+(seg <- read_sf(filepath, 
                 layer = "watercourse_100mseg_lines",
                 crs = 31370)
 )
 ```
 
 ```{r paged.print=FALSE, warning=FALSE}
-(pts <- read_sf(file.path(finalpath, 
-                          "watercourse_100mseg.gpkg"), 
+(pts <- read_sf(filepath, 
                 layer = "watercourse_100mseg_points",
                 crs = 31370))
 ```

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -23,7 +23,7 @@ if (!dir.exists(finalpath_segmentpoints)) dir.create(finalpath_segmentpoints)
 grass_location <- file.path(datapath, "grass_watercourses")
 if (!dir.exists(grass_location)) dir.create(file.path(grass_location, "PERMANENT"),
                                             recursive = TRUE)
-grass_exists <- file.exists(file.path(grass_location, "PERMANENT/PROJ_INFO"))
+grassdbase_exists <- file.exists(file.path(grass_location, "PERMANENT/PROJ_INFO"))
 if (.Platform$OS.type == "unix") {
   Sys.setenv(GRASS_PYTHON = system("which python3", intern = TRUE))
 }
@@ -34,7 +34,7 @@ if (.Platform$OS.type == "unix") {
 
 Read the `watercourse_segments` data source (this step still needs reproducibility).
 
-```{r eval=!grass_exists, paged.print=FALSE}
+```{r eval=!grassdbase_exists, paged.print=FALSE}
 watercourse_segments <- read_sf(file.path(datapath, "watercourse_segments"))
 ```
 
@@ -48,7 +48,7 @@ initGRASS(gisBase = link2GI::findGRASS()[1, 1],
 ```
 
 
-```{r eval=!grass_exists}
+```{r eval=!grassdbase_exists}
 # setting CRS and extent of the GRASS location, based on 'watercourse_segments'
 execGRASS("g.proj", flags = c("c", "quiet"), 
           georef = file.path(datapath, "watercourse_segments"))
@@ -67,7 +67,7 @@ use_sf()
 
 Add `watercourse_segments` data source to GRASS database:
 
-```{r eval=!grass_exists}
+```{r eval=!grassdbase_exists}
 execGRASS("v.in.ogr",
           input = file.path(datapath, "watercourse_segments"),
           output = "watercourse_segments")
@@ -79,7 +79,7 @@ To do this, we use the `v.split` command.
 
 <!-- g.manual v.split -->
 
-```{r eval=!grass_exists}
+```{r eval=!grassdbase_exists}
 execGRASS("v.split",
           flags = c("f", "overwrite"),
           input = "watercourse_segments",
@@ -101,7 +101,7 @@ This depends on the availability of the GRASS executables in the shell PATH, whi
 ]
 The `system()` command directly sends the below commands to the shell as one script for execution by GRASS.
 
-```{r eval=!grass_exists}
+```{r eval=!grassdbase_exists}
 system('v.category input=watercourse_100mseg_pre1 option=add layer=2 output=watercourse_100mseg
        # v.category input=watercourse_100mseg option=report
        # v.db.connect -p map=watercourse_100mseg
@@ -142,7 +142,7 @@ To do this, we use the `v.to.points` command.
 
 <!-- g.manual v.to.points -->
 
-```{r eval=!grass_exists}
+```{r eval=!grassdbase_exists}
 execGRASS("v.to.points",
           flags = c("overwrite"),
           input = "watercourse_100mseg",

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -56,13 +56,7 @@ initGRASS(gisBase = if (interactive()) gisbase_grass else params$gisbase_grass,
 ```{r eval=!grassdbase_exists}
 # setting CRS and extent of the GRASS location, based on 'watercourses'
 execGRASS("g.proj", flags = c("c", "quiet"), 
-          georef = file.path(datapath, "watercourses"))
-  # note: setting the extent should only affect raster computations (so we don't need it)
-b_box <- st_bbox(watercourses)
-execGRASS("g.region", flags = c("quiet"), 
-          n = as.character(b_box["ymax"]), s = as.character(b_box["ymin"]), 
-          e = as.character(b_box["xmax"]), w = as.character(b_box["xmin"]), 
-          res = "1")
+          epsg = 31370)
 ```
 
 
@@ -74,6 +68,7 @@ Add `watercourses` data source to GRASS database:
 
 ```{r eval=!grassdbase_exists}
 execGRASS("v.in.ogr",
+          "o",
           input = file.path(n2khab_datapath, "10_raw/watercourses"),
           output = "watercourses")
 ```

--- a/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
+++ b/src/generate_watercourse_100mseg/10_generate_watercourse_100mseg.Rmd
@@ -69,15 +69,58 @@ execGRASS("v.in.ogr",
 execGRASS("v.split",
           flags = c("f", "overwrite"),
           input = "watercourse_segments",
-          output = "watercourse_100mseg",
+          output = "watercourse_100mseg_pre1",
           length = 100)
 ```
 
-```{r eval=!grass_exists}
-system("v.category input=watercourse_100mseg option=report")
+```{r}
+system("v.category input=watercourse_100mseg_pre1 option=report")
 ```
 
+As seen from the above input, in accordance with the `v.split` manual, the categories and the attribute table of the original vector map are simply copied over.
+This means that the individual 100 m segments have no unique category, i.e. cannot have their own rows (with ID) in another attribute table.
+To get that, as explained in the documentation, we define a second layer^[To do that, the vector map `watercourse_100mseg_pre1` is copied, including layers & the link to the same attribute table.] with a unique category per feature (100 m segment) and create a new attribute table that links to the new layer (an attribute table always has exactly 1 row for each category and uses 1 layer to take categories from).
+Next, we copy the category of layer 1 as a mere attribute into a second column in the new attribute table (which is linked to layer 2), in order to define the link between the grouped category `cat_group` (categories of `watercourses_segements`) and the unique category `cat`.
 
+In order to execute the below four GRASS commands (not the outcommented ones), it may be necessary to break them down into separate `execGRASS()` statements.^[
+This depends on the availability of the GRASS executables in the shell PATH, which should have been set by `initGRASS()`.
+]
+The `system()` command directly sends the below commands to the shell as one script for execution by GRASS.
+
+```{r eval=!grass_exists}
+system('v.category input=watercourse_100mseg_pre1 option=add layer=2 output=watercourse_100mseg
+       # v.category input=watercourse_100mseg option=report
+       # v.db.connect -p map=watercourse_100mseg
+       v.db.addtable watercourse_100mseg layer=2
+       # v.db.connect -p map=watercourse_100mseg
+       # v.info -c watercourse_100mseg layer=2
+       # v.info -c watercourse_100mseg layer=1
+       v.db.addcolumn map=watercourse_100mseg layer=2 column="cat_group int"
+       v.to.db map=watercourse_100mseg layer=2 option=query query_layer=1 query_column=cat columns=cat_group --overwrite
+       # v.db.select map=watercourse_100mseg layer=2 | head
+       ')
+```
+
+<!-- Output from the v.to.db command: -->
+
+<!-- WARNING: Values in column <cat_group> will be overwritten -->
+<!-- Reading features... -->
+<!--  100% -->
+<!-- Querying database... -->
+<!--  100% -->
+<!-- Updating database... -->
+<!--  100% -->
+<!-- 263871 categories read from vector map (layer 2) -->
+<!-- 263871 records selected from table (layer 1) -->
+<!-- 263871 categories read from vector map exist in selection from table -->
+<!-- 263871 records updated/inserted (layer 2) -->
+
+
+
+<!-- v.db.connect -p map=watercourse_100mseg -->
+<!-- Vector map <watercourse_100mseg> is connected by: -->
+<!-- layer <1/watercourse_segments> table <watercourse_100mseg> in database <(...)/n2khab-preprocessing/src/generate_watercourse_100mseg/data/grass_watercourses/PERMANENT/sqlite/sqlite.db> through driver <sqlite> with key <cat> -->
+<!-- layer <2/watercourse_100mseg_2> table <watercourse_100mseg_2> in database <(...)/n2khab-preprocessing/src/generate_watercourse_100mseg/data/grass_watercourses/PERMANENT/sqlite/sqlite.db> through driver <sqlite> with key <cat> -->
 
 ### Generate `watercourse_100msegpoints` in GRASS
 
@@ -85,9 +128,67 @@ system("v.category input=watercourse_100mseg option=report")
 execGRASS("v.to.points",
           flags = c("overwrite"),
           input = "watercourse_100mseg",
+          layer = "2",
           output = "watercourse_100msegpoints",
           use = "end")
 ```
+
+<!-- v.info watercourse_100msegpoints layer=1 -->
+<!--  +----------------------------------------------------------------------------+ -->
+<!--  | Name:            watercourse_100msegpoints                                 | -->
+<!--  | Mapset:          PERMANENT                                                 | -->
+<!--  | Location:        grass_watercourses                                        | -->
+<!--  | Database:        (...)                                                     | -->
+<!--  | Title:                                                                     | -->
+<!--  | Map scale:       1:1                                                       | -->
+<!--  | Name of creator: floris                                                    | -->
+<!--  | Organization:                                                              | -->
+<!--  | Source date:     Fri Nov 27 16:14:43 2020                                  | -->
+<!--  | Timestamp (first layer): none                                              | -->
+<!--  |----------------------------------------------------------------------------| -->
+<!--  | Map format:      native                                                    | -->
+<!--  |----------------------------------------------------------------------------| -->
+<!--  |   Type of map: vector (level: 2)                                           | -->
+<!--  |                                                                            | -->
+<!--  |   Number of points:       263871          Number of centroids:  0          | -->
+<!--  |   Number of lines:        0               Number of boundaries: 0          | -->
+<!--  |   Number of areas:        0               Number of islands:    0          | -->
+<!--  |                                                                            | -->
+<!--  |   Map is 3D:              No                                               | -->
+<!--  |   Number of dblinks:      2                                                | -->
+<!--  |                                                                            | -->
+<!--  |   Projection: Belge 1972 / Belgian Lambert 72                              | -->
+<!--  |                                                                            | -->
+<!--  |               N:       244044.9074    S:   153062.38093558                 | -->
+<!--  |               E:       258444.2968    W:    23006.85298789                 | -->
+<!--  |                                                                            | -->
+<!--  |   Digitization threshold: 0                                                | -->
+<!--  |   Comment:                                                                 | -->
+<!--  |                                                                            | -->
+<!--  +----------------------------------------------------------------------------+ -->
+
+<!-- v.category input=watercourse_100msegpoints option=report -->
+<!-- Layer/table: 1/watercourse_100msegpoints_1 -->
+<!-- type       count        min        max -->
+<!-- point     263871          1     263871 -->
+<!-- line           0          0          0 -->
+<!-- boundary       0          0          0 -->
+<!-- centroid       0          0          0 -->
+<!-- area           0          0          0 -->
+<!-- face           0          0          0 -->
+<!-- kernel         0          0          0 -->
+<!-- all       263871          1     263871 -->
+<!-- Layer/table: 2/watercourse_100msegpoints_2 -->
+<!-- type       count        min        max -->
+<!-- point     263871          1     263871 -->
+<!-- line           0          0          0 -->
+<!-- boundary       0          0          0 -->
+<!-- centroid       0          0          0 -->
+<!-- area           0          0          0 -->
+<!-- face           0          0          0 -->
+<!-- kernel         0          0          0 -->
+<!-- all       263871          1     263871 -->
+
 
 # Checks on the data source
 

--- a/src/generate_watercourse_100mseg/99_sessioninfo.Rmd
+++ b/src/generate_watercourse_100mseg/99_sessioninfo.Rmd
@@ -4,7 +4,10 @@
 si <- devtools::session_info()
 p <- si$platform %>%
   do.call(what = "c")
-if ("sf" %in% si$packages$package) p <- c(p, sf_extSoftVersion())
+if ("sf" %in% si$packages$package) {
+  p <- c(p, sf_extSoftVersion())
+  names(p)[names(p) == "proj.4"] <- "PROJ"
+}
 if ("rgrass7" %in% si$packages$package) {
   p <- c(p, GRASS = link2GI::findGRASS()[1, "version"])
 }

--- a/src/generate_watercourse_100mseg/99_sessioninfo.Rmd
+++ b/src/generate_watercourse_100mseg/99_sessioninfo.Rmd
@@ -1,0 +1,22 @@
+# Used environment
+
+```{r session-info, results = "asis", echo=FALSE}
+si <- devtools::session_info()
+p <- si$platform %>%
+  do.call(what = "c")
+if ("sf" %in% si$packages$package) p <- c(p, sf_extSoftVersion())
+if ("rgrass7" %in% si$packages$package) {
+  p <- c(p, GRASS = link2GI::findGRASS()[1, "version"])
+}
+sprintf("- **%s**:\n %s\n", names(p), p) %>%
+  cat()
+```
+
+```{r results = "asis", echo=FALSE}
+si$packages %>%
+    as_tibble %>%
+    select(package, loadedversion, date, source) %>%
+pander::pandoc.table(caption = "(\\#tab:sessioninfo)Loaded R packages",
+                     split.table = Inf)
+```
+

--- a/src/generate_watercourse_100mseg/_bookdown.yml
+++ b/src/generate_watercourse_100mseg/_bookdown.yml
@@ -1,0 +1,4 @@
+book_filename: "generating_watercourse_segments.Rmd"
+new_session: FALSE
+rmd_files: # specifies the order of Rmd files; NOT needed when you use index.Rmd and an alphabetical order for other Rmd files
+    # - index.Rmd

--- a/src/generate_watercourse_100mseg/_bookdown.yml
+++ b/src/generate_watercourse_100mseg/_bookdown.yml
@@ -1,4 +1,4 @@
-book_filename: "generating_watercourse_segments.Rmd"
+book_filename: "generating_watercourse_100mseg.Rmd"
 new_session: FALSE
 rmd_files: # specifies the order of Rmd files; NOT needed when you use index.Rmd and an alphabetical order for other Rmd files
     # - index.Rmd

--- a/src/generate_watercourse_100mseg/generate_watercourse_100mseg.Rproj
+++ b/src/generate_watercourse_100mseg/generate_watercourse_100mseg.Rproj
@@ -1,0 +1,18 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: knitr
+LaTeX: XeLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
+BuildType: Website

--- a/src/generate_watercourse_100mseg/index.Rmd
+++ b/src/generate_watercourse_100mseg/index.Rmd
@@ -1,0 +1,51 @@
+---
+title: "Generate watercourse segments"
+# subtitle: "x"
+date: "`r lubridate::now()`"
+link-citations: true
+linkcolor: link.colour
+citecolor: link.colour
+urlcolor: link.colour
+geometry: margin=1in
+mainfont: "Calibri"
+fontsize: 11pt
+documentclass: "article"
+# csl: ../inbo.csl
+# bibliography: ../references.bib
+site: bookdown::bookdown_site
+output:
+  bookdown::html_document2:
+    code_folding: show
+    keep_md: TRUE
+    number_sections: yes
+    fig_caption: yes
+    df_print: paged
+    toc: TRUE
+    toc_float:
+      collapsed: FALSE
+      smooth_scroll: FALSE
+    includes:
+        in_header: ../header.html
+---
+
+```{r setup, include=FALSE}
+library(sf)
+library(dplyr)
+library(knitr)
+library(rprojroot)
+library(ggplot2)
+library(rgrass7)
+opts_chunk$set(
+  echo = TRUE,
+  dpi = 300
+)
+library(mapview)
+mapviewOptions(fgb = FALSE)
+```
+
+**Note: this is a bookdown project, supposed to be run from within the `src/generate_watercourse_100mseg` subfolder. You can use the `generate_watercourse_100mseg.Rproj` RStudio project file in this subfolder to run it.**
+
+
+
+
+

--- a/src/generate_watercourse_100mseg/index.Rmd
+++ b/src/generate_watercourse_100mseg/index.Rmd
@@ -32,6 +32,7 @@ output:
 ---
 
 ```{r setup, include=FALSE}
+renv::restore()
 library(sf)
 library(dplyr)
 library(stringr)

--- a/src/generate_watercourse_100mseg/index.Rmd
+++ b/src/generate_watercourse_100mseg/index.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Generate watercourse segments"
+title: "Generate watercourse 100 m segments"
 # subtitle: "x"
 date: "`r lubridate::now()`"
 link-citations: true

--- a/src/generate_watercourse_100mseg/index.Rmd
+++ b/src/generate_watercourse_100mseg/index.Rmd
@@ -12,6 +12,7 @@ fontsize: 11pt
 documentclass: "article"
 params:
   grass_reexport: FALSE
+  gisbase_grass: !r if (.Platform$OS.type == "windows") link2GI::paramGRASSw()$gisbase_GRASS[1] else link2GI::paramGRASSx()$gisbase_GRASS[1]
 # csl: ../inbo.csl
 # bibliography: ../references.bib
 site: bookdown::bookdown_site

--- a/src/generate_watercourse_100mseg/index.Rmd
+++ b/src/generate_watercourse_100mseg/index.Rmd
@@ -33,6 +33,7 @@ output:
 ```{r setup, include=FALSE}
 library(sf)
 library(dplyr)
+library(stringr)
 library(knitr)
 library(rprojroot)
 library(ggplot2)
@@ -41,8 +42,6 @@ opts_chunk$set(
   echo = TRUE,
   dpi = 300
 )
-library(mapview)
-mapviewOptions(fgb = FALSE)
 ```
 
 **Note: this is a bookdown project, supposed to be run from within the `src/generate_watercourse_100mseg` subfolder. You can use the `generate_watercourse_100mseg.Rproj` RStudio project file in this subfolder to run it.**

--- a/src/generate_watercourse_100mseg/index.Rmd
+++ b/src/generate_watercourse_100mseg/index.Rmd
@@ -10,6 +10,8 @@ geometry: margin=1in
 mainfont: "Calibri"
 fontsize: 11pt
 documentclass: "article"
+params:
+  grass_reexport: FALSE
 # csl: ../inbo.csl
 # bibliography: ../references.bib
 site: bookdown::bookdown_site
@@ -45,7 +47,8 @@ mapviewOptions(fgb = FALSE)
 
 **Note: this is a bookdown project, supposed to be run from within the `src/generate_watercourse_100mseg` subfolder. You can use the `generate_watercourse_100mseg.Rproj` RStudio project file in this subfolder to run it.**
 
-
+Upon building, a persistent GRASS project database will be created in which the data will be created.
+Because serious slowdown was encountered when exporting the points object (not the lines) to the final GPKG file, exporting (hence, recreating the GPKG file) will only be done when knitting with `params = list(grass_reexport = TRUE)`.
 
 
 

--- a/src/generate_watercourse_100mseg/renv.lock
+++ b/src/generate_watercourse_100mseg/renv.lock
@@ -442,15 +442,15 @@
     },
     "link2GI": {
       "Package": "link2GI",
-      "Version": "0.4.4",
+      "Version": "0.4-6",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
-      "RemoteRepo": "link2GI",
       "RemoteUsername": "r-spatial",
-      "RemoteRef": "7cbcbdb",
-      "RemoteSha": "7cbcbdb378f3e532d315447a02411c0e7bc60642",
-      "Hash": "2ea4b88dc3afa1528c7969b2a015a047"
+      "RemoteRepo": "link2GI",
+      "RemoteRef": "master",
+      "RemoteSha": "c4dd503747c9e75b8ea0053b2ef52296d830df7f",
+      "Hash": "2d6a2a532cccd84f05b5d72a07ec57ee"
     },
     "lubridate": {
       "Package": "lubridate",
@@ -636,10 +636,15 @@
     },
     "rgrass7": {
       "Package": "rgrass7",
-      "Version": "0.2-1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "ab882a7c47c336643f251e1a91696ae9"
+      "Version": "0.2-3",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteUsername": "rsbivand",
+      "RemoteRepo": "rgrass7",
+      "RemoteRef": "master",
+      "RemoteSha": "d726641b58219dc6b6d45cab46c1fd10d6d3346b",
+      "Hash": "f1b247f18e3cbefa4078a5ba7c8bac32"
     },
     "rlang": {
       "Package": "rlang",

--- a/src/generate_watercourse_100mseg/renv.lock
+++ b/src/generate_watercourse_100mseg/renv.lock
@@ -1,0 +1,848 @@
+{
+  "R": {
+    "Version": "4.0.3",
+    "Repositories": [
+      {
+        "Name": "RStudio",
+        "URL": "https://cloud.r-project.org"
+      },
+      {
+        "Name": "INLA",
+        "URL": "https://inla.r-inla-download.org/R/stable"
+      }
+    ]
+  },
+  "Packages": {
+    "BH": {
+      "Package": "BH",
+      "Version": "1.72.0-3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "8f9ce74c6417d61f0782cbae5fd2b7b0"
+    },
+    "DBI": {
+      "Package": "DBI",
+      "Version": "1.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "4744be45519d675af66c28478720fce5"
+    },
+    "DT": {
+      "Package": "DT",
+      "Version": "0.16",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "acac794cc3e393ca65f916e5ced5c1d2"
+    },
+    "KernSmooth": {
+      "Package": "KernSmooth",
+      "Version": "2.23-18",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "9e703ad8bf0e99f3691f05da32dfe68b"
+    },
+    "MASS": {
+      "Package": "MASS",
+      "Version": "7.3-53",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "d1bc1c8e9c0ace57ec9ffea01021d45f"
+    },
+    "Matrix": {
+      "Package": "Matrix",
+      "Version": "1.2-18",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "08588806cba69f04797dab50627428ed"
+    },
+    "R.methodsS3": {
+      "Package": "R.methodsS3",
+      "Version": "1.8.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "4bf6453323755202d5909697b6f7c109"
+    },
+    "R.oo": {
+      "Package": "R.oo",
+      "Version": "1.24.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "5709328352717e2f0a9c012be8a97554"
+    },
+    "R.utils": {
+      "Package": "R.utils",
+      "Version": "2.10.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a9e316277ff12a43997266f2f6567780"
+    },
+    "R6": {
+      "Package": "R6",
+      "Version": "2.5.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "b203113193e70978a696b2809525649d"
+    },
+    "RColorBrewer": {
+      "Package": "RColorBrewer",
+      "Version": "1.1-2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "e031418365a7f7a766181ab5a41a5716"
+    },
+    "Rcpp": {
+      "Package": "Rcpp",
+      "Version": "1.0.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "125dc7a0ed375eb68c0ce533b48d291f"
+    },
+    "XML": {
+      "Package": "XML",
+      "Version": "3.99-0.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "408d42d1359f2a84d377c1f7f0568624"
+    },
+    "askpass": {
+      "Package": "askpass",
+      "Version": "1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "e8a22846fff485f0be3770c2da758713"
+    },
+    "assertthat": {
+      "Package": "assertthat",
+      "Version": "0.2.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "50c838a310445e954bc13f26f26a6ecf"
+    },
+    "base64enc": {
+      "Package": "base64enc",
+      "Version": "0.1-3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "543776ae6848fde2f48ff3816d0628bc"
+    },
+    "bookdown": {
+      "Package": "bookdown",
+      "Version": "0.21",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "1bf627f1f77313e345f71e779b658578"
+    },
+    "brew": {
+      "Package": "brew",
+      "Version": "1.0-6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "92a5f887f9ae3035ac7afde22ba73ee9"
+    },
+    "brio": {
+      "Package": "brio",
+      "Version": "1.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "570a24963009b9cce0869a0463c83580"
+    },
+    "callr": {
+      "Package": "callr",
+      "Version": "3.5.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "b7d7f1e926dfcd57c74ce93f5c048e80"
+    },
+    "class": {
+      "Package": "class",
+      "Version": "7.3-17",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "9267f5dab59a4ef44229858a142bded1"
+    },
+    "classInt": {
+      "Package": "classInt",
+      "Version": "0.4-3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "17bdfa3c51df4a6c82484d13b11fb380"
+    },
+    "cli": {
+      "Package": "cli",
+      "Version": "2.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "3ef298932294b775fa0a3eeaa3a645b0"
+    },
+    "clipr": {
+      "Package": "clipr",
+      "Version": "0.7.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ebaa97ac99cc2daf04e77eecc7b781d7"
+    },
+    "colorspace": {
+      "Package": "colorspace",
+      "Version": "2.0-0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "abea3384649ef37f60ef51ce002f3547"
+    },
+    "commonmark": {
+      "Package": "commonmark",
+      "Version": "1.7",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "0f22be39ec1d141fd03683c06f3a6e67"
+    },
+    "covr": {
+      "Package": "covr",
+      "Version": "3.5.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6d80a9fc3c0c8473153b54fa54719dfd"
+    },
+    "crayon": {
+      "Package": "crayon",
+      "Version": "1.3.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "0d57bc8e27b7ba9e45dba825ebc0de6b"
+    },
+    "crosstalk": {
+      "Package": "crosstalk",
+      "Version": "1.1.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ae55f5d7c02f0ab43c58dd050694f2b4"
+    },
+    "curl": {
+      "Package": "curl",
+      "Version": "4.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "2b7d10581cc730804e9ed178c8374bd6"
+    },
+    "desc": {
+      "Package": "desc",
+      "Version": "1.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6c8fe8fa26a23b79949375d372c7b395"
+    },
+    "devtools": {
+      "Package": "devtools",
+      "Version": "2.3.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "415656f50722f5b6e6bcf80855ce11b9"
+    },
+    "diffobj": {
+      "Package": "diffobj",
+      "Version": "0.3.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "16533929cf545f3c9b796780cccf5eff"
+    },
+    "digest": {
+      "Package": "digest",
+      "Version": "0.6.27",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a0cbe758a531d054b537d16dff4d58a1"
+    },
+    "dplyr": {
+      "Package": "dplyr",
+      "Version": "1.0.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "d0509913b27ea898189ee664b6030dc2"
+    },
+    "e1071": {
+      "Package": "e1071",
+      "Version": "1.7-4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "7e9462e3e3e565f51fbec181dfcab890"
+    },
+    "ellipsis": {
+      "Package": "ellipsis",
+      "Version": "0.3.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "fd2844b3a43ae2d27e70ece2df1b4e2a"
+    },
+    "evaluate": {
+      "Package": "evaluate",
+      "Version": "0.14",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ec8ca05cffcc70569eaaad8469d2a3a7"
+    },
+    "fansi": {
+      "Package": "fansi",
+      "Version": "0.4.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "7fce217eaaf8016e72065e85c73027b5"
+    },
+    "farver": {
+      "Package": "farver",
+      "Version": "2.0.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "dad6793a5a1f73c8e91f1a1e3e834b05"
+    },
+    "fs": {
+      "Package": "fs",
+      "Version": "1.5.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "44594a07a42e5f91fac9f93fda6d0109"
+    },
+    "generics": {
+      "Package": "generics",
+      "Version": "0.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "4d243a9c10b00589889fe32314ffd902"
+    },
+    "ggplot2": {
+      "Package": "ggplot2",
+      "Version": "3.3.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "4ded8b439797f7b1693bd3d238d0106b"
+    },
+    "gh": {
+      "Package": "gh",
+      "Version": "1.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "05129b4387282404780d2f8593636388"
+    },
+    "git2r": {
+      "Package": "git2r",
+      "Version": "0.27.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "531a82d1beed1f545beb25f4f5945bf7"
+    },
+    "gitcreds": {
+      "Package": "gitcreds",
+      "Version": "0.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ceb3cc7bcf372186ade7954427f30d42"
+    },
+    "glue": {
+      "Package": "glue",
+      "Version": "1.4.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6efd734b14c6471cfe443345f3e35e29"
+    },
+    "gtable": {
+      "Package": "gtable",
+      "Version": "0.3.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ac5c6baf7822ce8732b343f14c072c4d"
+    },
+    "highr": {
+      "Package": "highr",
+      "Version": "0.8",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "4dc5bb88961e347a0f4d8aad597cbfac"
+    },
+    "htmltools": {
+      "Package": "htmltools",
+      "Version": "0.5.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "7d651b7131794fe007b1ad6f21aaa401"
+    },
+    "htmlwidgets": {
+      "Package": "htmlwidgets",
+      "Version": "1.5.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "0aaf56b7960bb066646e1868cadcaf07"
+    },
+    "httr": {
+      "Package": "httr",
+      "Version": "1.4.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a525aba14184fec243f9eaec62fbed43"
+    },
+    "ini": {
+      "Package": "ini",
+      "Version": "0.3.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6154ec2223172bce8162d4153cda21f7"
+    },
+    "isoband": {
+      "Package": "isoband",
+      "Version": "0.2.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6e58bd3d6b3dd82a944cd6f05ade228f"
+    },
+    "jsonlite": {
+      "Package": "jsonlite",
+      "Version": "1.7.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "1ec84e070b88b37ed169f19def40d47c"
+    },
+    "knitr": {
+      "Package": "knitr",
+      "Version": "1.30",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "eed7ee0d02eee88d53881cdc92457c62"
+    },
+    "labeling": {
+      "Package": "labeling",
+      "Version": "0.4.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "3d5108641f47470611a32d0bdf357a72"
+    },
+    "later": {
+      "Package": "later",
+      "Version": "1.1.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "d0a62b247165aabf397fded504660d8a"
+    },
+    "lattice": {
+      "Package": "lattice",
+      "Version": "0.20-41",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "fbd9285028b0263d76d18c95ae51a53d"
+    },
+    "lazyeval": {
+      "Package": "lazyeval",
+      "Version": "0.2.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "d908914ae53b04d4c0c0fd72ecc35370"
+    },
+    "lifecycle": {
+      "Package": "lifecycle",
+      "Version": "0.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "361811f31f71f8a617a9a68bf63f1f42"
+    },
+    "link2GI": {
+      "Package": "link2GI",
+      "Version": "0.4.4",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteRepo": "link2GI",
+      "RemoteUsername": "r-spatial",
+      "RemoteRef": "7cbcbdb",
+      "RemoteSha": "7cbcbdb378f3e532d315447a02411c0e7bc60642",
+      "Hash": "2ea4b88dc3afa1528c7969b2a015a047"
+    },
+    "lubridate": {
+      "Package": "lubridate",
+      "Version": "1.7.9",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "fc1c91e2e8d9e1fc932e75aa1ed989b7"
+    },
+    "magrittr": {
+      "Package": "magrittr",
+      "Version": "2.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "41287f1ac7d28a92f0a286ed507928d3"
+    },
+    "markdown": {
+      "Package": "markdown",
+      "Version": "1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "61e4a10781dd00d7d81dd06ca9b94e95"
+    },
+    "memoise": {
+      "Package": "memoise",
+      "Version": "1.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "58baa74e4603fcfb9a94401c58c8f9b1"
+    },
+    "mgcv": {
+      "Package": "mgcv",
+      "Version": "1.8-33",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "eb7b6439bc6d812eed2cddba5edc6be3"
+    },
+    "mime": {
+      "Package": "mime",
+      "Version": "0.9",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "e87a35ec73b157552814869f45a63aa3"
+    },
+    "munsell": {
+      "Package": "munsell",
+      "Version": "0.5.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6dfe8bf774944bd5595785e3229d8771"
+    },
+    "nlme": {
+      "Package": "nlme",
+      "Version": "3.1-150",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "82e52d2c6e674764ffb122d084afa96b"
+    },
+    "openssl": {
+      "Package": "openssl",
+      "Version": "1.4.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a399e4773075fc2375b71f45fca186c4"
+    },
+    "pander": {
+      "Package": "pander",
+      "Version": "0.6.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "121198ce37b5a6b5227edc5a38223da4"
+    },
+    "pillar": {
+      "Package": "pillar",
+      "Version": "1.4.7",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "3b3dd89b2ee115a8b54e93a34cd546b4"
+    },
+    "pkgbuild": {
+      "Package": "pkgbuild",
+      "Version": "1.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "404684bc4e3685007f9720adf13b06c1"
+    },
+    "pkgconfig": {
+      "Package": "pkgconfig",
+      "Version": "2.0.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "01f28d4278f15c76cddbea05899c5d6f"
+    },
+    "pkgload": {
+      "Package": "pkgload",
+      "Version": "1.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "b6b150cd4709e0c0c9b5d51ac4376282"
+    },
+    "praise": {
+      "Package": "praise",
+      "Version": "1.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a555924add98c99d2f411e37e7d25e9f"
+    },
+    "prettyunits": {
+      "Package": "prettyunits",
+      "Version": "1.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "95ef9167b75dde9d2ccc3c7528393e7e"
+    },
+    "processx": {
+      "Package": "processx",
+      "Version": "3.4.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "22aab6098cb14edd0a5973a8438b569b"
+    },
+    "promises": {
+      "Package": "promises",
+      "Version": "1.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a8730dcbdd19f9047774909f0ec214a4"
+    },
+    "ps": {
+      "Package": "ps",
+      "Version": "1.4.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "f5d7d94cc097aa9dade988e3e6715067"
+    },
+    "purrr": {
+      "Package": "purrr",
+      "Version": "0.3.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "97def703420c8ab10d8f0e6c72101e02"
+    },
+    "raster": {
+      "Package": "raster",
+      "Version": "3.4-5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a3ded548110163cf499d63c3932dd499"
+    },
+    "rcmdcheck": {
+      "Package": "rcmdcheck",
+      "Version": "1.3.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ed95895886dab6d2a584da45503555da"
+    },
+    "rematch2": {
+      "Package": "rematch2",
+      "Version": "2.1.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "76c9e04c712a05848ae7a23d2f170a40"
+    },
+    "remotes": {
+      "Package": "remotes",
+      "Version": "2.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "430a0908aee75b1fcba0e62857cab0ce"
+    },
+    "renv": {
+      "Package": "renv",
+      "Version": "0.12.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "b5510c50c7f31d453c385c7b460af2b9"
+    },
+    "rex": {
+      "Package": "rex",
+      "Version": "1.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "093584b944440c5cd07a696b3c8e0e4c"
+    },
+    "rgrass7": {
+      "Package": "rgrass7",
+      "Version": "0.2-1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ab882a7c47c336643f251e1a91696ae9"
+    },
+    "rlang": {
+      "Package": "rlang",
+      "Version": "0.4.9",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "9d7aba7bed9a79e2403b4777428a2b12"
+    },
+    "rmarkdown": {
+      "Package": "rmarkdown",
+      "Version": "2.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "20a0a94af9e8f7040510447763aab3e9"
+    },
+    "roxygen2": {
+      "Package": "roxygen2",
+      "Version": "7.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "fcd94e00cc409b25d07ca50f7bf339f5"
+    },
+    "rprojroot": {
+      "Package": "rprojroot",
+      "Version": "2.0.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "249d8cd1e74a8f6a26194a91b47f21d1"
+    },
+    "rstudioapi": {
+      "Package": "rstudioapi",
+      "Version": "0.13",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "06c85365a03fdaf699966cc1d3cf53ea"
+    },
+    "rversions": {
+      "Package": "rversions",
+      "Version": "2.0.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "0ec41191f744d0f5afad8c6f35cc36e4"
+    },
+    "scales": {
+      "Package": "scales",
+      "Version": "1.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6f76f71042411426ec8df6c54f34e6dd"
+    },
+    "sessioninfo": {
+      "Package": "sessioninfo",
+      "Version": "1.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "308013098befe37484df72c39cf90d6e"
+    },
+    "sf": {
+      "Package": "sf",
+      "Version": "0.9-6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "bf0ef23231efe31576e08d69772892ef"
+    },
+    "sp": {
+      "Package": "sp",
+      "Version": "1.4-4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "e0485290545c0e768c2b50390114da1f"
+    },
+    "stringi": {
+      "Package": "stringi",
+      "Version": "1.5.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a063ebea753c92910a4cca7b18bc1f05"
+    },
+    "stringr": {
+      "Package": "stringr",
+      "Version": "1.4.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "0759e6b6c0957edb1311028a49a35e76"
+    },
+    "sys": {
+      "Package": "sys",
+      "Version": "3.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "b227d13e29222b4574486cfcbde077fa"
+    },
+    "testthat": {
+      "Package": "testthat",
+      "Version": "3.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "13298cedd051cb7b8a8972d380b559a6"
+    },
+    "tibble": {
+      "Package": "tibble",
+      "Version": "3.0.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "71dffd8544691c520dd8e41ed2d7e070"
+    },
+    "tidyselect": {
+      "Package": "tidyselect",
+      "Version": "1.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6ea435c354e8448819627cf686f66e0a"
+    },
+    "tinytex": {
+      "Package": "tinytex",
+      "Version": "0.27",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "264b4a31d35bb6833566a7763356ab63"
+    },
+    "units": {
+      "Package": "units",
+      "Version": "0.6-7",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "4a3df844d6d35ca2ba2b7ba95446b955"
+    },
+    "usethis": {
+      "Package": "usethis",
+      "Version": "1.6.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "c541a7aed5f7fb3b487406bf92842e34"
+    },
+    "utf8": {
+      "Package": "utf8",
+      "Version": "1.1.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "4a5081acfb7b81a572e4384a7aaf2af1"
+    },
+    "vctrs": {
+      "Package": "vctrs",
+      "Version": "0.3.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "d25c5bea636cf892edbfd64fc3d20c20"
+    },
+    "viridisLite": {
+      "Package": "viridisLite",
+      "Version": "0.3.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ce4f6271baa94776db692f1cb2055bee"
+    },
+    "waldo": {
+      "Package": "waldo",
+      "Version": "0.2.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "181d1a31b1ba2009ef20926f2ee0570c"
+    },
+    "whisker": {
+      "Package": "whisker",
+      "Version": "0.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ca970b96d894e90397ed20637a0c1bbe"
+    },
+    "withr": {
+      "Package": "withr",
+      "Version": "2.3.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "7307d79f58d1885b38c4f4f1a8cb19dd"
+    },
+    "xfun": {
+      "Package": "xfun",
+      "Version": "0.19",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a42372606cb76f34da9d090326e9f955"
+    },
+    "xml2": {
+      "Package": "xml2",
+      "Version": "1.3.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "d4d71a75dd3ea9eb5fa28cc21f9585e2"
+    },
+    "xopen": {
+      "Package": "xopen",
+      "Version": "1.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6c85f015dee9cc7710ddd20f86881f58"
+    },
+    "yaml": {
+      "Package": "yaml",
+      "Version": "2.2.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "2826c5d9efb0a88f657c7a679c7106db"
+    }
+  }
+}

--- a/src/generate_watercourse_100mseg/renv/.gitignore
+++ b/src/generate_watercourse_100mseg/renv/.gitignore
@@ -1,0 +1,4 @@
+library/
+lock/
+python/
+staging/

--- a/src/generate_watercourse_100mseg/renv/activate.R
+++ b/src/generate_watercourse_100mseg/renv/activate.R
@@ -1,0 +1,400 @@
+
+local({
+
+  # the requested version of renv
+  version <- "0.12.3"
+
+  # the project directory
+  project <- getwd()
+
+  # avoid recursion
+  if (!is.na(Sys.getenv("RENV_R_INITIALIZING", unset = NA)))
+    return(invisible(TRUE))
+
+  # signal that we're loading renv during R startup
+  Sys.setenv("RENV_R_INITIALIZING" = "true")
+  on.exit(Sys.unsetenv("RENV_R_INITIALIZING"), add = TRUE)
+
+  # signal that we've consented to use renv
+  options(renv.consent = TRUE)
+
+  # load the 'utils' package eagerly -- this ensures that renv shims, which
+  # mask 'utils' packages, will come first on the search path
+  library(utils, lib.loc = .Library)
+
+  # check to see if renv has already been loaded
+  if ("renv" %in% loadedNamespaces()) {
+
+    # if renv has already been loaded, and it's the requested version of renv,
+    # nothing to do
+    spec <- .getNamespaceInfo(.getNamespace("renv"), "spec")
+    if (identical(spec[["version"]], version))
+      return(invisible(TRUE))
+
+    # otherwise, unload and attempt to load the correct version of renv
+    unloadNamespace("renv")
+
+  }
+
+  # load bootstrap tools   
+  bootstrap <- function(version, library) {
+  
+    # read repos (respecting override if set)
+    repos <- Sys.getenv("RENV_CONFIG_REPOS_OVERRIDE", unset = NA)
+    if (is.na(repos))
+      repos <- getOption("repos")
+  
+    # fix up repos
+    on.exit(options(repos = repos), add = TRUE)
+    repos[repos == "@CRAN@"] <- "https://cloud.r-project.org"
+    options(repos = repos)
+  
+    # attempt to download renv
+    tarball <- tryCatch(renv_bootstrap_download(version), error = identity)
+    if (inherits(tarball, "error"))
+      stop("failed to download renv ", version)
+  
+    # now attempt to install
+    status <- tryCatch(renv_bootstrap_install(version, tarball, library), error = identity)
+    if (inherits(status, "error"))
+      stop("failed to install renv ", version)
+  
+  }
+  
+  renv_bootstrap_download_impl <- function(url, destfile) {
+  
+    mode <- "wb"
+  
+    # https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17715
+    fixup <-
+      Sys.info()[["sysname"]] == "Windows" &&
+      substring(url, 1L, 5L) == "file:"
+  
+    if (fixup)
+      mode <- "w+b"
+  
+    download.file(
+      url      = url,
+      destfile = destfile,
+      mode     = mode,
+      quiet    = TRUE
+    )
+  
+  }
+  
+  renv_bootstrap_download <- function(version) {
+  
+    # if the renv version number has 4 components, assume it must
+    # be retrieved via github
+    nv <- numeric_version(version)
+    components <- unclass(nv)[[1]]
+  
+    methods <- if (length(components) == 4L) {
+      list(renv_bootstrap_download_github)
+    } else {
+      list(
+        renv_bootstrap_download_cran_latest,
+        renv_bootstrap_download_cran_archive
+      )
+    }
+  
+    for (method in methods) {
+      path <- tryCatch(method(version), error = identity)
+      if (is.character(path) && file.exists(path))
+        return(path)
+    }
+  
+    stop("failed to download renv ", version)
+  
+  }
+  
+  renv_bootstrap_download_cran_latest <- function(version) {
+  
+    repos <- renv_bootstrap_download_cran_latest_find(version)
+  
+    message("* Downloading renv ", version, " from CRAN ... ", appendLF = FALSE)
+  
+    info <- tryCatch(
+      download.packages("renv", repos = repos, destdir = tempdir(), quiet = TRUE),
+      condition = identity
+    )
+  
+    if (inherits(info, "condition")) {
+      message("FAILED")
+      return(FALSE)
+    }
+  
+    message("OK")
+    info[1, 2]
+  
+  }
+  
+  renv_bootstrap_download_cran_latest_find <- function(version) {
+  
+    # check for renv on CRAN matching this version
+    all <- unique(c(
+      getOption("repos"),
+      getOption("renv.bootstrap.repos", default = "https://cloud.r-project.org")
+    ))
+  
+    for (repos in all) {
+  
+      db <- tryCatch(
+        as.data.frame(available.packages(repos = repos), stringsAsFactors = FALSE),
+        error = identity
+      )
+  
+      if (inherits(db, "error"))
+        next
+  
+      entry <- db[db$Package %in% "renv" & db$Version %in% version, ]
+      if (nrow(entry) == 0)
+        next
+  
+      return(repos)
+  
+    }
+  
+    fmt <- "renv %s is not available from your declared package repositories"
+    stop(sprintf(fmt, version))
+  
+  }
+  
+  renv_bootstrap_download_cran_archive <- function(version) {
+  
+    name <- sprintf("renv_%s.tar.gz", version)
+    repos <- getOption("repos")
+    urls <- file.path(repos, "src/contrib/Archive/renv", name)
+    destfile <- file.path(tempdir(), name)
+  
+    message("* Downloading renv ", version, " from CRAN archive ... ", appendLF = FALSE)
+  
+    for (url in urls) {
+  
+      status <- tryCatch(
+        renv_bootstrap_download_impl(url, destfile),
+        condition = identity
+      )
+  
+      if (identical(status, 0L)) {
+        message("OK")
+        return(destfile)
+      }
+  
+    }
+  
+    message("FAILED")
+    return(FALSE)
+  
+  }
+  
+  renv_bootstrap_download_github <- function(version) {
+  
+    enabled <- Sys.getenv("RENV_BOOTSTRAP_FROM_GITHUB", unset = "TRUE")
+    if (!identical(enabled, "TRUE"))
+      return(FALSE)
+  
+    # prepare download options
+    pat <- Sys.getenv("GITHUB_PAT")
+    if (nzchar(Sys.which("curl")) && nzchar(pat)) {
+      fmt <- "--location --fail --header \"Authorization: token %s\""
+      extra <- sprintf(fmt, pat)
+      saved <- options("download.file.method", "download.file.extra")
+      options(download.file.method = "curl", download.file.extra = extra)
+      on.exit(do.call(base::options, saved), add = TRUE)
+    } else if (nzchar(Sys.which("wget")) && nzchar(pat)) {
+      fmt <- "--header=\"Authorization: token %s\""
+      extra <- sprintf(fmt, pat)
+      saved <- options("download.file.method", "download.file.extra")
+      options(download.file.method = "wget", download.file.extra = extra)
+      on.exit(do.call(base::options, saved), add = TRUE)
+    }
+  
+    message("* Downloading renv ", version, " from GitHub ... ", appendLF = FALSE)
+  
+    url <- file.path("https://api.github.com/repos/rstudio/renv/tarball", version)
+    name <- sprintf("renv_%s.tar.gz", version)
+    destfile <- file.path(tempdir(), name)
+  
+    status <- tryCatch(
+      renv_bootstrap_download_impl(url, destfile),
+      condition = identity
+    )
+  
+    if (!identical(status, 0L)) {
+      message("FAILED")
+      return(FALSE)
+    }
+  
+    message("Done!")
+    return(destfile)
+  
+  }
+  
+  renv_bootstrap_install <- function(version, tarball, library) {
+  
+    # attempt to install it into project library
+    message("* Installing renv ", version, " ... ", appendLF = FALSE)
+    dir.create(library, showWarnings = FALSE, recursive = TRUE)
+  
+    # invoke using system2 so we can capture and report output
+    bin <- R.home("bin")
+    exe <- if (Sys.info()[["sysname"]] == "Windows") "R.exe" else "R"
+    r <- file.path(bin, exe)
+    args <- c("--vanilla", "CMD", "INSTALL", "-l", shQuote(library), shQuote(tarball))
+    output <- system2(r, args, stdout = TRUE, stderr = TRUE)
+    message("Done!")
+  
+    # check for successful install
+    status <- attr(output, "status")
+    if (is.numeric(status) && !identical(status, 0L)) {
+      header <- "Error installing renv:"
+      lines <- paste(rep.int("=", nchar(header)), collapse = "")
+      text <- c(header, lines, output)
+      writeLines(text, con = stderr())
+    }
+  
+    status
+  
+  }
+  
+  renv_bootstrap_prefix <- function() {
+  
+    # construct version prefix
+    version <- paste(R.version$major, R.version$minor, sep = ".")
+    prefix <- paste("R", numeric_version(version)[1, 1:2], sep = "-")
+  
+    # include SVN revision for development versions of R
+    # (to avoid sharing platform-specific artefacts with released versions of R)
+    devel <-
+      identical(R.version[["status"]],   "Under development (unstable)") ||
+      identical(R.version[["nickname"]], "Unsuffered Consequences")
+  
+    if (devel)
+      prefix <- paste(prefix, R.version[["svn rev"]], sep = "-r")
+  
+    # build list of path components
+    components <- c(prefix, R.version$platform)
+  
+    # include prefix if provided by user
+    prefix <- Sys.getenv("RENV_PATHS_PREFIX")
+    if (nzchar(prefix))
+      components <- c(prefix, components)
+  
+    # build prefix
+    paste(components, collapse = "/")
+  
+  }
+  
+  renv_bootstrap_library_root <- function(project) {
+  
+    path <- Sys.getenv("RENV_PATHS_LIBRARY", unset = NA)
+    if (!is.na(path))
+      return(path)
+  
+    path <- Sys.getenv("RENV_PATHS_LIBRARY_ROOT", unset = NA)
+    if (!is.na(path)) {
+      id <- substring(renv_bootstrap_hash_text(project), 1L, 8L)
+      name <- paste(basename(project), id, sep = "-")
+      return(file.path(path, name))
+    }
+  
+    file.path(project, "renv/library")
+  
+  }
+  
+  renv_bootstrap_validate_version <- function(version) {
+  
+    loadedversion <- utils::packageDescription("renv", fields = "Version")
+    if (version == loadedversion)
+      return(TRUE)
+  
+    # assume four-component versions are from GitHub; three-component
+    # versions are from CRAN
+    components <- strsplit(loadedversion, "[.-]")[[1]]
+    remote <- if (length(components) == 4L)
+      paste("rstudio/renv", loadedversion, sep = "@")
+    else
+      paste("renv", loadedversion, sep = "@")
+  
+    fmt <- paste(
+      "renv %1$s was loaded from project library, but this project is configured to use renv %2$s.",
+      "Use `renv::record(\"%3$s\")` to record renv %1$s in the lockfile.",
+      "Use `renv::restore(packages = \"renv\")` to install renv %2$s into the project library.",
+      sep = "\n"
+    )
+  
+    msg <- sprintf(fmt, loadedversion, version, remote)
+    warning(msg, call. = FALSE)
+  
+    FALSE
+  
+  }
+  
+  renv_bootstrap_hash_text <- function(text) {
+  
+    hashfile <- tempfile("renv-hash-")
+    on.exit(unlink(hashfile), add = TRUE)
+  
+    writeLines(text, con = hashfile)
+    tools::md5sum(hashfile)
+  
+  }
+  
+  renv_bootstrap_load <- function(project, libpath, version) {
+  
+    # try to load renv from the project library
+    if (!requireNamespace("renv", lib.loc = libpath, quietly = TRUE))
+      return(FALSE)
+  
+    # warn if the version of renv loaded does not match
+    renv_bootstrap_validate_version(version)
+  
+    # load the project
+    renv::load(project)
+  
+    TRUE
+  
+  }
+
+  # construct path to library root
+  root <- renv_bootstrap_library_root(project)
+
+  # construct library prefix for platform
+  prefix <- renv_bootstrap_prefix()
+
+  # construct full libpath
+  libpath <- file.path(root, prefix)
+
+  # attempt to load
+  if (renv_bootstrap_load(project, libpath, version))
+    return(TRUE)
+
+  # load failed; inform user we're about to bootstrap
+  prefix <- paste("# Bootstrapping renv", version)
+  postfix <- paste(rep.int("-", 77L - nchar(prefix)), collapse = "")
+  header <- paste(prefix, postfix)
+  message(header)
+
+  # perform bootstrap
+  bootstrap(version, libpath)
+
+  # exit early if we're just testing bootstrap
+  if (!is.na(Sys.getenv("RENV_BOOTSTRAP_INSTALL_ONLY", unset = NA)))
+    return(TRUE)
+
+  # try again to load
+  if (requireNamespace("renv", lib.loc = libpath, quietly = TRUE)) {
+    message("* Successfully installed and loaded renv ", version, ".")
+    return(renv::load())
+  }
+
+  # failed to download or load renv; warn the user
+  msg <- c(
+    "Failed to find an renv installation: the project will not be loaded.",
+    "Use `renv::activate()` to re-initialize the project."
+  )
+
+  warning(paste(msg, collapse = "\n"), call. = FALSE)
+
+})

--- a/src/generate_watercourse_100mseg/renv/settings.dcf
+++ b/src/generate_watercourse_100mseg/renv/settings.dcf
@@ -1,0 +1,7 @@
+external.libraries:
+ignored.packages:
+package.dependency.fields: Imports, Depends, LinkingTo
+r.version:
+snapshot.type: implicit
+use.cache: TRUE
+vcs.ignore.library: TRUE


### PR DESCRIPTION
Initial code added.

I plan to add/do:

- [x] code necessary to uniquely identify corresponding segments and endpoints with a common, unique code
- ~steps to write / read intermediate output from GRASS as gpkg on GDrive~ (unneeded since data source has been entirely prepared in GRASS)
- ~first steps to attach GRTSmaster_habitats address to points~ (chosen to leave this out of this processed data source since it is specific to the handling of the 3260 sampling frame, it would not be the generally recommendable practice to make unique (c.q. spatially balanced) IDs for these segments and points)
- ~code to further clean variable names and simplify the data in some standardized way~ (unneeded since data source has been entirely prepared in GRASS)
- [X] code to write the result to disk (maybe as one GPKG)
- [X] first checks on the result
- [ ] better referral to `watercourses` (consolidate raw data source)
- [ ] provide a function `read_watercourse_100mseg()` in n2khab
- [ ] consolidate the processed data source on Zenodo

@ToonHub I'll let you know when the processed data source is ready.

First impression of segments + points (from GRASS gui):

<details><summary><strong>Screenshot</strong></summary>

![afbeelding](https://user-images.githubusercontent.com/19164640/100455743-86991c00-30bf-11eb-9d7f-8f784f85cbec.png)

</details>