### PR TITLE
habmap_stdized, watsurf_hab: add _bookdown.yml

### DIFF
--- a/src/generate_habitatmap_stdized/_bookdown.yml
+++ b/src/generate_habitatmap_stdized/_bookdown.yml
@@ -1,0 +1,4 @@
+book_filename: "generating_habitatmap_stdized.Rmd"
+new_session: FALSE
+rmd_files: # specifies the order of Rmd files; NOT needed when you use index.Rmd and an alphabetical order for other Rmd files
+    # - index.Rmd

--- a/src/generate_watersurfaces_hab/_bookdown.yml
+++ b/src/generate_watersurfaces_hab/_bookdown.yml
@@ -1,0 +1,4 @@
+book_filename: "generating_watersurfaces_hab.Rmd"
+new_session: FALSE
+rmd_files: # specifies the order of Rmd files; NOT needed when you use index.Rmd and an alphabetical order for other Rmd files
+    # - index.Rmd


### PR DESCRIPTION
This avoids the default `_main.html` filename to be used when knitting.