### PR TITLE
Generating raster_runif: some additional changes

### DIFF
--- a/src/generate_raster_runif/10_raster_runif.Rmd
+++ b/src/generate_raster_runif/10_raster_runif.Rmd
@@ -269,3 +269,20 @@ tibble(value_runif = values(raster_runif_buffer_mask)) %>%
   
 ```
 
+Check CRS with the GDAL utility `gdalsrsinfo` (because `raster` does not succeed well here):
+
+```{r}
+raster_runif_wkt <- 
+  gdalUtils::gdalsrsinfo(filepath, o = "wkt2_2018") %>% 
+  .[. != ""] %>% 
+  paste(collapse = "\n")
+cat(raster_runif_wkt)
+```
+
+Compare CRS with expected:
+
+```{r}
+raster_runif_wkt == sf::st_crs(31370)$wkt
+```
+
+

--- a/src/generate_raster_runif/10_raster_runif.Rmd
+++ b/src/generate_raster_runif/10_raster_runif.Rmd
@@ -236,11 +236,11 @@ filepath <-  file.path(fileman_up("n2khab_data"), "10_raw/raster_runif/raster_ru
 ```
 
 
-```{r, eval = params$overwrite_result}
+```{r}
 writeRaster(raster_runif_buffer_mask,
             filepath,
             format = "GTiff",
-            overwrite = TRUE)
+            overwrite = params$overwrite_result)
 ```
 
 

--- a/src/generate_raster_runif/99_sessioninfo.Rmd
+++ b/src/generate_raster_runif/99_sessioninfo.Rmd
@@ -5,8 +5,16 @@ si <- devtools::session_info()
 p <- si$platform %>%
   do.call(what = "c")
 if ("sf" %in% si$packages$package) {
-  p <- c(p, sf_extSoftVersion())
-  names(p)[names(p) == "proj.4"] <- "PROJ"
+  sf_ext <- sf_extSoftVersion()
+  names(sf_ext)[names(sf_ext) == "proj.4"] <- "PROJ"
+  names(sf_ext) <- paste("(sf)", names(sf_ext))
+  p <- c(p, sf_ext)
+}
+if ("rgdal" %in% si$packages$package) {
+  rgdal_ext <- rgdal_extSoftVersion()
+  rgdal_ext <- rgdal_ext[names(rgdal_ext) != "sp"]
+  names(rgdal_ext) <- paste("(rgdal)", names(rgdal_ext))
+  p <- c(p, rgdal_ext)
 }
 if ("rgrass7" %in% si$packages$package) {
   p <- c(p, GRASS = link2GI::findGRASS()[1, "version"])

--- a/src/generate_raster_runif/index.Rmd
+++ b/src/generate_raster_runif/index.Rmd
@@ -45,7 +45,8 @@ output:
 
 options(stringsAsFactors = FALSE,
         scipen = 999, 
-        digits = 15)
+        digits = 15,
+        rgdal_show_exportToProj4_warnings = "none")
 
 renv::restore()
 library(sf)
@@ -62,8 +63,6 @@ opts_chunk$set(
   echo = TRUE,
   dpi = 300
 )
-
-options(rgdal_show_exportToProj4_warnings = "none")
 ```
 
 **Note: this is a bookdown project, supposed to be run from within the `src/generate_raster_runif` subfolder. You can use the `generate_raster_runif.Rproj` RStudio project file in this subfolder to run it.**

--- a/src/generate_raster_runif/index.Rmd
+++ b/src/generate_raster_runif/index.Rmd
@@ -51,6 +51,7 @@ options(stringsAsFactors = FALSE,
 renv::restore()
 library(sf)
 library(raster)
+library(rgdal)
 library(knitr)
 library(n2khab)
 library(kableExtra)

--- a/src/generate_raster_runif/renv.lock
+++ b/src/generate_raster_runif/renv.lock
@@ -202,6 +202,13 @@
       "Repository": "CRAN",
       "Hash": "ebaa97ac99cc2daf04e77eecc7b781d7"
     },
+    "codetools": {
+      "Package": "codetools",
+      "Version": "0.2-18",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "019388fc48e48b3da0d3a76ff94608a8"
+    },
     "colorspace": {
       "Package": "colorspace",
       "Version": "2.0-0",
@@ -342,12 +349,26 @@
       "Repository": "CRAN",
       "Hash": "81c3244cab67468aac4c60550832655d"
     },
+    "foreach": {
+      "Package": "foreach",
+      "Version": "1.5.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "e32cfc0973caba11b65b1fa691b4d8c9"
+    },
     "fs": {
       "Package": "fs",
       "Version": "1.5.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "44594a07a42e5f91fac9f93fda6d0109"
+    },
+    "gdalUtils": {
+      "Package": "gdalUtils",
+      "Version": "2.0.3.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "05ee75453c7c7cf6741a050af30927ba"
     },
     "generics": {
       "Package": "generics",
@@ -474,6 +495,13 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "b2008df40fb297e3fef135c7e8eeec1a"
+    },
+    "iterators": {
+      "Package": "iterators",
+      "Version": "1.0.13",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "64778782a89480e9a644f69aad9a2877"
     },
     "jsonlite": {
       "Package": "jsonlite",

--- a/src/generate_raster_runif/renv.lock
+++ b/src/generate_raster_runif/renv.lock
@@ -795,6 +795,13 @@
       "Repository": "CRAN",
       "Hash": "8482bbeef0c194ac236aef7c51ee375f"
     },
+    "rgdal": {
+      "Package": "rgdal",
+      "Version": "1.5-23",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "bb6f643247d35c947e9f113567e2bf7a"
+    },
     "rlang": {
       "Package": "rlang",
       "Version": "0.4.10",


### PR DESCRIPTION
I made these updates while attempting to run the code and reproduce the GeoTIFF. @ToonHub they should not affect your result when rerunning.

- explicitly load `rgdal` because otherwise `renv` (with default settings) misses it. That's because `rgdal` is not a strict dependency of raster, while the functions we use do need it. So the bookdown could not compile in a fresh `renv` environment. This is a frequently encountered problem, I believe this is the easiest hack.
- for the sake of reproducibly creating the output, don't set `eval=FALSE` by default for the `writeRaster()` chunk. From your parameter's name 'overwrite_result', this parameter seems to work more sensibly when used as argument of `writeRaster(overwrite=)`, so I've moved it there.
- added a check of the file CRS, this is important since slightly differing CRS representations lead to clashes when combining data sets (which we counter within some `n2khab` functions). Meanwhile, discovered that the CRS that `raster` returns when reading the file has a partly deficient WKT, so turned to the `gdalsrsinfo` utility for that.
- some minor updates

A sidenote. I could not reproduce the GeoTIFF, while repeated runs did result in the same file (but with another hash than yours). After further inspection, it seems that it is because the generated random numbers differ from ± the 7th digit onwards (in the bookdown setup, precision is set at 15 digits) - and that may be also triggered by the large amount of generated numbers. This seems something very R related, i.e. different behaviour on different platforms. I have not pursued this, it's not that important. It may be possible to achieve reproducibility with specific arguments of `set.seed()`, but it might remain something that's partly time and system dependent. One further possible reason is that my R version is on 4.0.5.

- If you'd like to have a look, you could re-run without the `digits = 15` option, maybe that result would be cross-platform reproducible - a wild guess.