### PR TITLE
generate_raster_runif: use rgdal for CRS check, drop gdalUtils

### DIFF
--- a/src/generate_raster_runif/10_raster_runif.Rmd
+++ b/src/generate_raster_runif/10_raster_runif.Rmd
@@ -288,13 +288,10 @@ tibble(value_runif = values(raster_runif_buffer_mask)) %>%
   
 ```
 
-Check CRS with the GDAL utility `gdalsrsinfo` (because `raster` does not succeed well here):
+Check CRS with `rgdal` (because `raster` does not succeed well here):
 
 ```{r}
-raster_runif_wkt <- 
-  gdalUtils::gdalsrsinfo(filepath, o = "wkt2_2018") %>% 
-  .[. != ""] %>% 
-  paste(collapse = "\n")
+raster_runif_wkt <- rgdal::readGDAL(filepath, silent = TRUE) %>% wkt
 cat(raster_runif_wkt)
 ```
 

--- a/src/generate_raster_runif/generate_raster_runif.Rproj
+++ b/src/generate_raster_runif/generate_raster_runif.Rproj
@@ -16,4 +16,3 @@ AutoAppendNewline: Yes
 StripTrailingWhitespace: Yes
 
 BuildType: Website
-WebsitePath: C:/Users/toon_westra/Rprojecten/n2khab-preprocessing/src/generate_raster_runif

--- a/src/generate_raster_runif/renv.lock
+++ b/src/generate_raster_runif/renv.lock
@@ -202,13 +202,6 @@
       "Repository": "CRAN",
       "Hash": "ebaa97ac99cc2daf04e77eecc7b781d7"
     },
-    "codetools": {
-      "Package": "codetools",
-      "Version": "0.2-18",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "019388fc48e48b3da0d3a76ff94608a8"
-    },
     "colorspace": {
       "Package": "colorspace",
       "Version": "2.0-0",
@@ -349,26 +342,12 @@
       "Repository": "CRAN",
       "Hash": "81c3244cab67468aac4c60550832655d"
     },
-    "foreach": {
-      "Package": "foreach",
-      "Version": "1.5.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "e32cfc0973caba11b65b1fa691b4d8c9"
-    },
     "fs": {
       "Package": "fs",
       "Version": "1.5.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "44594a07a42e5f91fac9f93fda6d0109"
-    },
-    "gdalUtils": {
-      "Package": "gdalUtils",
-      "Version": "2.0.3.2",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "05ee75453c7c7cf6741a050af30927ba"
     },
     "generics": {
       "Package": "generics",
@@ -495,13 +474,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "b2008df40fb297e3fef135c7e8eeec1a"
-    },
-    "iterators": {
-      "Package": "iterators",
-      "Version": "1.0.13",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "64778782a89480e9a644f69aad9a2877"
     },
     "jsonlite": {
       "Package": "jsonlite",


### PR DESCRIPTION
This hopefully leads to a better CRS test result in your case. Can you check that @ToonHub? If unsuccessful, try to see what are the differences between both WKT strings (some code is available in the `raster` issue, referred in #56). Also I'm curious what the environment returns in your case (that appendix was extended in #57); perhaps there are multiple PROJ/GDAL versions at work.

[generating_raster_runif.html.zip](https://github.com/inbo/n2khab-preprocessing/files/6390797/generating_raster_runif.html.zip)

I dropped a machine-specific line (website path) from the Rproj file (2fe5612), it generates errors on other machines than yours, upon loading the RStudio project. After pulling this change locally, you best close and reopen the RStudio project. Or better still, just run `git pull` in the project or git directory after closing RStudio.