### PR TITLE
Updates to the 'habitatmap' notebook

### DIFF
--- a/src/compute_filehashes.R
+++ b/src/compute_filehashes.R
@@ -1,5 +1,6 @@
 library(openssl)
 library(tidyverse)
+library(n2khab)
 
 mypath <- fileman_up("n2khab_data")
 

--- a/src/miscellaneous/habitatmap.Rmd
+++ b/src/miscellaneous/habitatmap.Rmd
@@ -2,7 +2,7 @@
 title: "Handling the habitatmap"
 date: '`r paste("Version",lubridate::now())`'
 output:
-  html_notebook:
+  html_document:
     number_sections: yes
     code_folding: show
     includes:

--- a/src/miscellaneous/habitatmap.Rmd
+++ b/src/miscellaneous/habitatmap.Rmd
@@ -29,14 +29,17 @@ opts_chunk$set(
 # A few checks of the habitatmap_stdized data source
 
 ```{r}
-result <- read_habitatmap_stdized()
+filepath <- file.path(fileman_up("n2khab_data"),
+                      "20_processed/habitatmap_stdized/habitatmap_stdized.gpkg")
+habitatmap_polygons <- st_read(filepath, layer = "habitatmap_polygons")
+habitatmap_types <- st_read(filepath, layer = "habitatmap_types")
 ```
 
 
 Do all polygons from the sf object have a unique ID?
 
 ```{r}
-result$habitatmap_polygons %>% 
+habitatmap_polygons %>% 
   st_drop_geometry %>% 
   count(polygon_id) %>% 
   filter(n > 1) %>% 
@@ -46,23 +49,23 @@ result$habitatmap_polygons %>%
 Is the number of unique IDs in the dataframe the same as the number of polygons in the sf object?
 
 ```{r}
-result$habitatmap_types %>% 
+habitatmap_types %>% 
   distinct(polygon_id) %>% 
-  nrow == nrow(result$habitatmap_polygons)
+  nrow == nrow(habitatmap_polygons)
 ```
 
 Do all polygon IDs from the dataframe coincide with those of the sf object?
 
 ```{r message=FALSE}
-result$habitatmap_types %>% 
-  inner_join(result$habitatmap_polygons) %>% 
-  nrow == nrow(result$habitatmap_types)
+habitatmap_types %>% 
+  inner_join(habitatmap_polygons) %>% 
+  nrow == nrow(habitatmap_types)
 ```
 
 Number of polygons with phab = 0:
 
 ```{r}
-result$habitatmap_types %>% 
+habitatmap_types %>% 
   filter(phab == 0) %>% 
   nrow()
 ```

--- a/src/miscellaneous/habitatmap.Rmd
+++ b/src/miscellaneous/habitatmap.Rmd
@@ -33,10 +33,11 @@ result <- read_habitatmap_stdized()
 ```
 
 
-Do all polygons from the sf object have a unique ID? (Beware, this calculation takes approx. 2-3 minutes; it has been disabled)
+Do all polygons from the sf object have a unique ID?
 
-```{r eval=FALSE}
+```{r}
 result$habitatmap_polygons %>% 
+  st_drop_geometry %>% 
   count(polygon_id) %>% 
   filter(n > 1) %>% 
   nrow == 0

--- a/src/miscellaneous/habitatmap.Rmd
+++ b/src/miscellaneous/habitatmap.Rmd
@@ -15,16 +15,9 @@ output:
 
 ```{r setup, message=FALSE, echo=FALSE}
 options(stringsAsFactors = FALSE)
-# library(sp)
 library(sf)
-library(raster)
-library(tidyverse)
+library(dplyr)
 library(n2khab)
-# # library(plotly)
-# library(rasterVis)
-# library(stars)
-# library(units)
-# library(tmap)
 library(knitr)
 opts_chunk$set(
   echo = TRUE,

--- a/src/miscellaneous/habitatmap.Rmd
+++ b/src/miscellaneous/habitatmap.Rmd
@@ -35,6 +35,19 @@ habitatmap_polygons <- st_read(filepath, layer = "habitatmap_polygons")
 habitatmap_types <- st_read(filepath, layer = "habitatmap_types")
 ```
 
+Checking the CRS stated in the file as "`r st_crs(habitatmap_polygons)$input`": does it actually conform to the EPSG standard (in order to prevent CRS clashes in workflows)?
+
+- can the EPSG code be exported?
+
+```{r}
+!is.na(st_crs(habitatmap_polygons)$epsg)
+```
+
+- does it conform to EPSG:31370?
+
+```{r}
+st_crs(habitatmap_polygons) == st_crs(31370)
+```
 
 Do all polygons from the sf object have a unique ID?
 

--- a/src/miscellaneous/habitatmap.Rmd
+++ b/src/miscellaneous/habitatmap.Rmd
@@ -29,7 +29,7 @@ opts_chunk$set(
 # A few checks of the habitatmap_stdized data source
 
 ```{r}
-result <- read_habitatmap_stdized("../../n2khab_data")
+result <- read_habitatmap_stdized()
 ```
 
 
@@ -45,7 +45,7 @@ result$habitatmap_polygons %>%
 Is the number of unique IDs in the dataframe the same as the number of polygons in the sf object?
 
 ```{r}
-result$habitatmap_patches %>% 
+result$habitatmap_types %>% 
   distinct(polygon_id) %>% 
   nrow == nrow(result$habitatmap_polygons)
 ```
@@ -53,15 +53,15 @@ result$habitatmap_patches %>%
 Do all polygon IDs from the dataframe coincide with those of the sf object?
 
 ```{r message=FALSE}
-result$habitatmap_patches %>% 
+result$habitatmap_types %>% 
   inner_join(result$habitatmap_polygons) %>% 
-  nrow == nrow(result$habitatmap_patches)
+  nrow == nrow(result$habitatmap_types)
 ```
 
 Number of polygons with phab = 0:
 
 ```{r}
-result$habitatmap_patches %>% 
+result$habitatmap_types %>% 
   filter(phab == 0) %>% 
   nrow()
 ```


### PR DESCRIPTION
This html_document received some updates in the course of checking habitatmap_stdized.

- The [compiled document of 12 Feb](https://github.com/inbo/n2khab-preprocessing/files/5973101/habitatmap.html.zip) refers to the state of `habitatmap_stdized` in https://github.com/inbo/n2khab-preprocessing/pull/50#pullrequestreview-589277914, where it is referred to as "_the checks present in this file (it's on the `hms_fv` branch now, as an update of the original file on `master`)_" and available in the '2020' link.
- [This](https://github.com/inbo/n2khab-preprocessing/files/6915642/habitatmap.html.zip) is its up-to-date compiled state, with all checks succeeding.

Its source code just hadn't been merged yet, doing that now.