### PR TITLE
Updating shallowgroundwater raw data source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ src/private_code.R
 *.qgz
 grass_*/
 watercourse_segments/
+*/update_shallowgroundwater/data/

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ src/private_code.R
 grass_*/
 watercourse_segments/
 */update_shallowgroundwater/data/
+**/images/

--- a/src/update_shallowgroundwater/.Rprofile
+++ b/src/update_shallowgroundwater/.Rprofile
@@ -1,0 +1,1 @@
+source("renv/activate.R")

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -425,6 +425,27 @@ walk(1:3, function(i) {
 
 ## Intersect the new zones, subtract the original `shallowgroundwater` layer and append
 
+```{r}
+# use of future unneeded in this case (runs quickly)
+f <- future({
+  elapsed <- 
+    system.time(
+      result <- qgis_run_algorithm("native:union",
+                                   INPUT = file.path(datapath, 
+                                                     "new_areas.gpkg") %>% 
+                                     str_c("|layername=",
+                                           "buffered_obliggwdep_within_soilanthrop_buff200"),
+                                   OVERLAY = file.path(datapath, 
+                                                     "new_areas.gpkg") %>% 
+                                     str_c("|layername=",
+                                           "narrow_soilanthrop_with_obliggwdep_buff200"))
+    )
+  list(result = result, elapsed = elapsed)
+}, seed = NULL)
+# resolved(f)
+value(f, stdout = FALSE, signal = FALSE)$elapsed
+res <- value(f, stdout = FALSE)$result$OUTPUT
+```
 
 
 

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -99,9 +99,8 @@ if (any(checksums !=
           shallowgroundwater.sbn = "cb0c0bb2565829ff", 
           shallowgroundwater.sbx = "9419203dc2909044",
           shallowgroundwater.shp = "5cf8969daa942dec", 
-          shallowgroundwater.shp.xml = "6df16307066eec5e",
           shallowgroundwater.shx = "bc582622278dba1c"))
-) warning("Beware, your version of shallowgroundwater is not the one for which this code was intended!")
+) stop("Beware, your version of shallowgroundwater is not the one for which this code was intended!")
 ```
 
 ```{r}

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -266,7 +266,7 @@ gpkg_sg_ring_exists <-
                         "sg_ring.gpkg"))
 ```
 
-```{r eval=!gpkg_sg_ring_exists || params$rewrite_intermediate_files}
+```{r eval=!gpkg_sg_ring_exists}
 system.time({
 sg_union <-
   sg_repairedgeom %>%
@@ -285,7 +285,7 @@ write_sf(sg_ring,
          delete_dsn = TRUE)
 ```
 
-```{r eval=gpkg_sg_ring_exists && !params$rewrite_intermediate_files, include=FALSE}
+```{r eval=gpkg_sg_ring_exists, include=FALSE}
 sg_ring <- 
   read_sf(file.path(datapath, 
                     "sg_ring.gpkg"))
@@ -319,7 +319,7 @@ hmt_pol_obliggwdep %>%
 ```
 
 
-```{r eval=!gpkg_buffered_obliggwdep_within_sg_ring_exists || params$rewrite_intermediate_files}
+```{r}
 plan(multisession) # future kept here as demonstration
 ```
 

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -508,6 +508,26 @@ The result is written as ``r output_filename``.
 sg_extended <- 
   read_sf(res_filepath2) %>% 
   select(-starts_with("fid")) %>% 
+  {if (params$union_sg) . else {
+    select(.,
+           geomorph_wcoast = K_GMK_, 
+           anthrop_gwdep,
+           narrowanthrop_gwdep,
+           drainage = BOD_DRA, 
+           dunes_gwdep,
+           peat_profile = BOD_PROV, 
+           peat_substr = BOD_SUB, 
+           peat_parentmat = BOD_MOEV, 
+           peat_texture = BOD_TEX, 
+           phys_system = FYS_, 
+           zwin = K_ZWIN_, 
+           habitat_1130 = HAB_1130, 
+           gwdepth_coast = K_GWD_, 
+           gwdepth_local = GWM_, 
+           seepage = BDS_, 
+           peat_survey = VEK_, 
+           duneslack = K_DUINV_)
+  }} %>% 
   mutate(across(where(is.logical), ~ifelse(is.na(.), FALSE, .)))
 ```
 

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -390,12 +390,13 @@ gpkg_newareas_exists <-
 buffered_obliggwdep_within_soilanthrop_buff200 <- 
   buffered_obliggwdep_within_soilanthrop %>% 
   st_buffer(200) %>% 
-  st_cast("MULTIPOLYGON")
+  st_union
 
-narrow_soilanthrop_with_obliggwdep_buff200 <- 
+narrow_soilanthrop_with_obliggwdep_buff200 <-
   narrow_soilanthrop_with_obliggwdep %>% 
   select(-everything()) %>% 
-  st_buffer(200)
+  st_buffer(200) %>% 
+  st_union
 
 buffered_obliggwdep_within_sg_ring_buff200 <- 
   buffered_obliggwdep_within_sg_ring %>% 

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -221,11 +221,16 @@ Resulting object: `buffered_obliggwdep_within_soilanthrop`.
 
 After several iterations, the below used conditions on `thinness` and `obliggwdep_pol_frac` appeared satisfying.
 
-```{r out.width='800px', out.height='500px'}
+```{r}
 narrow_soilanthrop_with_obliggwdep <- 
   soil_anthrop %>% 
   filter(thinness < 0.15,
-         obliggwdep_pol_frac > 0.04)
+         obliggwdep_pol_frac > 0.04) %>% 
+  st_cast("MULTIPOLYGON")
+```
+
+
+```{r out.width='800px', out.height='500px'}
 mapview(narrow_soilanthrop_with_obliggwdep,
         zcol = "thinness",
         color = "pink3",
@@ -251,51 +256,6 @@ narrow_soilanthrop_with_obliggwdep_buff200 <-
 
 ## Buffer 500 m around obliggwdep types, that are within 200 m of `shallowgroundwater`
 
-We need to do this in GRASS because of the large `shallowgroundwater` input.
-
-```{r}
-grasspath <- file.path(datapath, "grass")
-grass_exists <- file.exists(file.path(grasspath, 
-                                      "PERMANENT/PROJ_INFO"))
-if (!dir.exists(grasspath)) dir.create(grasspath)
-```
-
-
-```{r results="hide"}
-# CREATE OR LINK to a permanent GRASS location
-initGRASS(gisBase = gisbase_grass,
-          gisDbase = datapath,
-          home = grasspath,
-          location = "grass",
-          mapset = "PERMANENT", 
-          override = TRUE)
-if (!grass_exists) {
-    execGRASS("g.proj", c("c", "quiet"), 
-              epsg = 31370)
-}
-# gmeta()
-use_sf()
-```
-
-
-```{r}
-stopifnot(file.exists(file.path(grasspath, 
-                                "PERMANENT/PROJ_INFO")))
-```
-
-```{r warning=FALSE, results="hide", eval=!grass_exists}
-execGRASS("v.in.ogr",
-          input = normalizePath(file.path(fileman_up("n2khab_data"),
-                                          "10_raw/shallowgroundwater")),
-          output = "sg",
-          flags = c("o", # assume CRS is same as from GRASS, i.e. set CRS as EPSG:31370
-                    "overwrite")
-          )
-```
-
-```{r}
-writeVECT(hmt_pol_obliggwdep, "hmt_pol_obliggwdep")
-```
 
 ```{r eval=!gpkg_sg_exists}
 sg_repairedgeom <- 
@@ -314,77 +274,21 @@ sg_repairedgeom <-
 ```
 
 ```{r include=FALSE}
-gpkg_sg_buff_exists <- 
+gpkg_sg_ring_exists <- 
   file.exists(file.path(datapath, 
-                        "sg_buff.gpkg"))
+                        "sg_ring.gpkg"))
 ```
 
-
-```{r eval=!gpkg_sg_buff_exists}
-sg_buff <- 
-  sg_repairedgeom %>% 
-  st_buffer(200) %>% 
-  st_cast("MULTIPOLYGON")
-sg_buff %>% 
-  st_write(file.path(datapath, 
-                     "sg_buff.gpkg"),
-           delete_dsn = TRUE)
-```
-
-```{r eval=gpkg_sg_buff_exists, include=FALSE}
-sg_buff <- 
-  read_sf(file.path(datapath, 
-                    "sg_buff.gpkg"))
-```
-
-```{r}
-# qgis_algorithms() %>% filter(str_detect(algorithm, "diff"))
-# qgis_show_help("native:difference")
-hmt_pol_obliggwdep %>% 
-  st_make_valid %>% 
-  st_write(file.path(datapath, 
-                     "hmt_pol_obliggwdep.gpkg"),
-           delete_dsn = TRUE)
-sg_ring <- 
-  qgis_run_algorithm("native:difference",
-                     INPUT = file.path(datapath, 
-                                       "sg_buff.gpkg"),
-                     OVERLAY = file.path(datapath, 
-                                         "sg_repairedgeom.gpkg"))
-system.time(
-  sg_ring <- 
-    qgis_run_algorithm("grass7:v.overlay",
-                       ainput = file.path(datapath, 
-                                          "sg_buff.gpkg"),
-                       binput = file.path(datapath, 
-                                          "sg_repairedgeom.gpkg"),
-                       operator = "2")
-)
-```
-
-
-```{r}
-execGRASS("v.in.ogr",
-          input = file.path(datapath, "sg_repairedgeom.gpkg"),
-          output = "sg_repairedgeom",
-          flags = "overwrite")
-execGRASS("v.in.ogr",
-          input = file.path(datapath, "sg_buff.gpkg"),
-          output = "sg_buff",
-          flags = c("c", "overwrite"))
-```
-
-
-```{r}
+```{r eval=!gpkg_sg_ring_exists}
 system.time({
 sg_union <-
   sg_repairedgeom %>%
   st_union()
-sg_buff2 <-
+sg_buff <-
   sg_union %>%
   st_buffer(200)
 sg_ring <- 
-  st_difference(sg_buff2, sg_union)
+  st_difference(sg_buff, sg_union)
 })
 #     user   system  elapsed 
 # 2044.543    0.000 2045.678 
@@ -394,11 +298,17 @@ st_write(sg_ring,
          delete_dsn = TRUE)
 ```
 
-```{r eval=!gpkg_exists}
-# following step takes several minutes!
+```{r eval=gpkg_sg_ring_exists, include=FALSE}
+sg_ring <- 
+  read_sf(file.path(datapath, 
+                    "sg_ring.gpkg"))
+```
+
+```{r eval=FALSE, echo=FALSE}
+# following step takes too much time! Interrupted this manually.
 system.time(
 buffered_obliggwdep_nearsg <-
-  hmt_pol_obliggwdep[sg_ring, ] %>% 
+  hmt_pol_obliggwdep[sg_ring, ] %>% # especially this takes an age. Will use QGIS here.
   st_make_valid(.) %>% 
   st_buffer(500) %>% 
   st_union()

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -428,6 +428,7 @@ gpkg_sg_extended_exists <- file.exists(file.path(datapath, "sg_extended.gpkg"))
 
 
 ```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists}
+# qgis_arguments("native:union")
 # use of future unneeded in this case (runs quickly)
 f <- future({
   elapsed <- 

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -21,7 +21,7 @@ Such 'areas of interest' are e.g. anthropogenic soil type polygons.
 - In the case of anthropogenic soil type polygons, we will subseqently limit those areas to _buffers (of `r params$buffer_obliggwdep` m) around habitatmap polygons with 'obliggwdep' types_ -- still subsequently clipping along the borders of the aforementioned areas.
 So in practice, we first select the habitatmap polygons with 'obliggwdep' types that intersect the anthropogenic soil type polygons, we buffer them, and we clip the result along the areas of interest.
   - The buffers around habitatmap polygons with 'obliggwdep' types are applied since it is expected that shallow groundwater (with potentially 'locally groundwater dependent' types) will occur in the vicinity of those polygons.
-- In a next step, we want to add a _buffer of `r params$buffer_areas` m_ around the obtained polygons, and also around the original `shallowgroundwater` layer.
+- In a next step, we want to add a _buffer of `r params$buffer_areas` m_ around the obtained polygons.
 This is done as a further means of conservative area selection: we rather need too much area than too little, for protection against over-restricting target populations.
 
 The areas of interest are:
@@ -35,13 +35,12 @@ Hence we select them as a whole instead of selecting buffers around the habitatm
 - Hence an additional condition was required: a minimal amount of 'obliggwdep' type must be present in such polygons.
 
 Finally, we stitch the parts.
-The resulting new version of `shallowgroundwater` is written here as **`sg_extended_2.gpkg`**.
+The resulting new version of `shallowgroundwater` is written here as **`sg2_extended_2.gpkg`**.
 
-Hence we will have three separate sources, which we will document as three extra TRUE/FALSE column inside `sg_extended_2.gpkg`:
+Hence we will have two separate sources, which we will document as two extra TRUE/FALSE column inside `sg2_extended_2.gpkg`:
 
 - `within_soilanthrop_plus_buffer`
 - `narrow_soilanthrop_plus_buffer`
-- `sg_plus_buffer`
 
 Where an area overlapped between several of these sources, more than one column is set as `TRUE`.
 
@@ -302,31 +301,12 @@ narrow_soilanthrop_with_obliggwdep_buff <-
   st_union %>% 
   st_as_sf
 
-f <- future({
-  elapsed <- 
-    system.time(
-      result <-
-        sg_repairedgeom %>% 
-        st_union %>% 
-        st_buffer(params$buffer_areas) %>% 
-        st_as_sf
-    )
-  list(result = result, elapsed = elapsed)
-}, seed = NULL)
-# resolved(f)
-# value(f, stdout = FALSE)$elapsed
-#    user  system elapsed 
-# 876.952   1.416 879.065
-sg_buff <- value(f, stdout = FALSE)$result
-
 if (gpkg_newareas_exists) unlink(file.path(datapath, "new_areas.gpkg"))
 
 list(buffered_obliggwdep_within_soilanthrop_buff =
        buffered_obliggwdep_within_soilanthrop_buff,
      narrow_soilanthrop_with_obliggwdep_buff =
-       narrow_soilanthrop_with_obliggwdep_buff,
-     sg_buff =
-       sg_buff) %>% 
+       narrow_soilanthrop_with_obliggwdep_buff) %>% 
   walk2(names(.),
         ~write_sf(.x,
                   dsn = file.path(datapath, "new_areas.gpkg"),
@@ -343,7 +323,7 @@ walk(1:3, function(i) {
 })
 ```
 
-We write the three resulting layers into `new_areas.gpkg`:
+We write the two resulting layers into `new_areas.gpkg`:
 
 ```{r paged.print=FALSE}
 st_layers(file.path(datapath, "new_areas.gpkg"))
@@ -358,7 +338,7 @@ The unioning is done in order to prevent overlapping polygons within the same la
 We extend `shallowgroundwater` as described in section \@ref(method).
 
 ```{r include=FALSE}
-gpkg_sg_extended_exists <- file.exists(file.path(datapath, "sg_extended_2.gpkg"))
+gpkg_sg_extended_exists <- file.exists(file.path(datapath, "sg2_extended_2.gpkg"))
 ```
 
 ```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists, warning=FALSE}
@@ -388,8 +368,10 @@ f <- future({
                                    INPUT = 
                                      res_filepath,
                                    OVERLAY = 
-                                     sg_buff %>% 
-                                     mutate(sg_plus_buffer = TRUE))
+                                     sg_repairedgeom %>% 
+                                     st_union %>% 
+                                     st_as_sf %>% 
+                                     mutate(sg = TRUE))
     )
   list(result = result, elapsed = elapsed)
 }, seed = NULL)
@@ -398,7 +380,7 @@ value(f, stdout = FALSE, signal = FALSE)$elapsed
 res_filepath2 <- value(f, stdout = FALSE)$result$OUTPUT %>% as.character
 ```
 
-The result is written as `sg_extended_2.gpkg`.
+The result is written as `sg2_extended_2.gpkg`.
 
 ```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists}
 sg_extended <- 
@@ -410,7 +392,7 @@ sg_extended <-
 ```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists}
 system.time(
 st_write(sg_extended,
-         file.path(datapath, "sg_extended_2.gpkg"),
+         file.path(datapath, "sg2_extended_2.gpkg"),
          layer = "sg_extended",
          delete_dsn = TRUE,
          quiet = TRUE)

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -341,7 +341,7 @@ obliggwdep_sgring_qgis <- value(f, stdout = FALSE) # blocks calling R session if
 
 
 ```{r eval=!gpkg_buffered_obliggwdep_within_sg_ring_exists}
-# use of future unneeded in this case (runs quickly
+# use of future unneeded in this case (runs quickly)
 f <- future({
   elapsed <- 
     system.time(

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -505,7 +505,7 @@ res_filepath2 <- value(f, stdout = FALSE)$result$OUTPUT %>% as.character
 The result is written as ``r output_filename``.
 
 ```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists}
-sg_extended <- 
+sg_extended <-
   read_sf(res_filepath2) %>% 
   select(-starts_with("fid")) %>% 
   {if (params$union_sg) . else {
@@ -528,6 +528,7 @@ sg_extended <-
            peat_survey = VEK_, 
            duneslack = K_DUINV_)
   }} %>% 
+  mutate(across(where(is.integer), ~ifelse(is.na(.) | . == 0L, FALSE, TRUE))) %>%
   mutate(across(where(is.logical), ~ifelse(is.na(.), FALSE, .)))
 ```
 

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -457,10 +457,12 @@ f <- future({
     system.time(
       result <- qgis_run_algorithm("native:union",
                                    INPUT = 
-                                     sg_repairedgeom,
+                                     res_filepath,
                                    OVERLAY = 
-                                     res_filepath
-)
+                                     sg_repairedgeom %>% 
+                                     st_union %>% 
+                                     st_as_sf %>% 
+                                     mutate(sg = TRUE))
     )
   list(result = result, elapsed = elapsed)
 }, seed = NULL)

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -63,17 +63,10 @@ sgpath <- find_root_file("n2khab_data/10_raw/shallowgroundwater",
 if (!dir.exists(sgpath) | list.files(sgpath) %>% length == 0) {
   dir.create(sgpath)
   drive_auth(email = TRUE)
-  # downloads "ZonesOndiepGrondwater_2019-03-29.zip":
-  as_id("1n_LyvRDDzL3hraoMWf_pBhabTYiWsiD0") %>% 
-    drive_download(file.path(tempdir(), "file.zip"), 
+  # downloads "ZonesOndiepGrondwater_20211004.gpkg":
+  as_id("12EEomOBcKg0NMUPwsFDyKhqJSvrS8xs8") %>% 
+    drive_download(file.path(sgpath, "shallowgroundwater.gpkg"), 
                    overwrite = TRUE)
-  unzip(file.path(tempdir(), "file.zip"), 
-        exdir = sgpath)
-  filenames <- list.files(sgpath, full.names = TRUE)
-  file.rename(filenames,
-              str_replace(filenames, 
-                          "ZonesOndiepGrondwater", 
-                          "shallowgroundwater"))
 }
 ```
 
@@ -91,13 +84,7 @@ checksums %>%
 
 ```{r}
 if (any(checksums != 
-        c(shallowgroundwater.cpg = "a0915c78be995614",
-          shallowgroundwater.dbf = "c4ceda6d9466bd89", 
-          shallowgroundwater.qpj = "853f02064884203e",
-          shallowgroundwater.sbn = "cb0c0bb2565829ff", 
-          shallowgroundwater.sbx = "9419203dc2909044",
-          shallowgroundwater.shp = "5cf8969daa942dec", 
-          shallowgroundwater.shx = "bc582622278dba1c"))
+        c(shallowgroundwater.gpkg = "68646fe7362d8bf6"))
 ) stop("Beware, your version of shallowgroundwater is not the one for which this code was intended!")
 ```
 
@@ -126,7 +113,7 @@ gpkg_sg_exists <-
 ```
 
 ```{r eval=!gpkg_sg_exists}
-sg <- read_sf(sgpath, crs = 31370)
+sg <- read_sf(file.path(sgpath, "shallowgroundwater.gpkg"), crs = 31370)
 ```
 
 ```{r eval=FALSE, echo=FALSE}

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -9,7 +9,7 @@ It is more specifically applied to restrict the 'locally groundwater dependent' 
 - Data and metadata are in [a GDrive folder](https://drive.google.com/drive/u/0/folders/1S9colwuaMNmB58u4RUnB0MqZLyIUZ9rT).
 - More info about checking the data source: see <https://github.com/inbo/n2khab-mne-design/pull/74> and links therein.
 
-Based on an evaluation that uses the '(almost) everywhere groundwater dependent' types, the current state still mismatches a significant proportion of those types.
+Based on an evaluation that uses the '(almost) everywhere groundwater dependent' types, the current state still mismatches a proportion of those types.
 Hence, the area it covers needs to be made broader.
 
 ## Aim and method {#method}
@@ -33,7 +33,7 @@ Hence we select them as a whole instead of selecting buffers around the habitatm
 - An appropriate algorithm had to be made that selects meaningful polygons - at first it resulted in complete cities meeting the narrowness requirement (since they are part of anthropogenic soil type polygons with long, narrow parts).
 - Hence an additional condition was required: a minimal amount of 'obliggwdep' type must be present in such polygons.
 
-```{r}
+```{r echo=FALSE}
 output_filename <- params$output_filename
 ```
 
@@ -219,7 +219,7 @@ soil_anthrop %>%
   geom_histogram(binwidth = 0.01, fill = "white", colour = "grey70")
 ```
 
-Creating a geospatial object of dune texture polygons, with the areal fraction occupied by `habitatmap_terr` polygons having 'obliggwdep' types:
+Creating a geospatial object of dune texture polygons, with the areal fraction occupied by `habitatmap_terr` polygons having 'obliggwdep' types.
 
 ```{r}
 soil_dunes <- 

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -285,7 +285,7 @@ gpkg_exists <-
                         "buffered_obliggwdep_within_soilanthrop.gpkg"))
 ```
 
-```{r eval=!gpkg_exists || params$rewrite_intermediate_files}
+```{r eval=!gpkg_exists || params$rewrite_intermediate_aoi_files}
 # following step takes several minutes!
 buffered_obliggwdep_within_soilanthrop <-
   hmt_pol_obliggwdep[soil_anthrop, ] %>% 
@@ -299,7 +299,7 @@ write_sf(buffered_obliggwdep_within_soilanthrop,
          delete_dsn = TRUE)
 ```
 
-```{r eval=gpkg_exists && !params$rewrite_intermediate_files, include = FALSE}
+```{r eval=gpkg_exists && !params$rewrite_intermediate_aoi_files, include = FALSE}
 buffered_obliggwdep_within_soilanthrop <- 
   read_sf(file.path(datapath, 
                     "buffered_obliggwdep_within_soilanthrop.gpkg"))
@@ -317,7 +317,7 @@ gpkg_exists <-
                         "buffered_obliggwdep_within_soildunes.gpkg"))
 ```
 
-```{r eval=!gpkg_exists || params$rewrite_intermediate_files}
+```{r eval=!gpkg_exists || params$rewrite_intermediate_aoi_files}
 # following step takes several minutes!
 buffered_obliggwdep_within_soildunes <-
   hmt_pol_obliggwdep[soil_dunes, ] %>% 
@@ -331,7 +331,7 @@ write_sf(buffered_obliggwdep_within_soildunes,
          delete_dsn = TRUE)
 ```
 
-```{r eval=gpkg_exists && !params$rewrite_intermediate_files, include = FALSE}
+```{r eval=gpkg_exists && !params$rewrite_intermediate_aoi_files, include = FALSE}
 buffered_obliggwdep_within_soildunes <- 
   read_sf(file.path(datapath, 
                     "buffered_obliggwdep_within_soildunes.gpkg"))
@@ -374,7 +374,7 @@ gpkg_newareas_exists <-
 plan(multisession) # future kept here as demonstration
 ```
 
-```{r eval=!gpkg_newareas_exists || params$rewrite_intermediate_files, warning=FALSE}
+```{r eval=!gpkg_newareas_exists || params$rewrite_intermediate_aoi_files, warning=FALSE}
 if (gpkg_newareas_exists) unlink(file.path(datapath, "new_areas.gpkg"))
 
 list(buffered_obliggwdep_within_soilanthrop =
@@ -395,7 +395,7 @@ list(buffered_obliggwdep_within_soilanthrop =
                   layer = .y))
 ```
 
-```{r eval=gpkg_newareas_exists && !params$rewrite_intermediate_files, include=FALSE}
+```{r eval=gpkg_newareas_exists && !params$rewrite_intermediate_aoi_files, include=FALSE}
 walk(1:3, function(i) {
   layername <- st_layers(file.path(datapath, "new_areas.gpkg"))$name[i]
   assign(layername,

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -3,7 +3,7 @@
 ## Current, intermediate state of the `shallowgroundwater` data source
 
 A `shallowgroundwater` data source was prepared by Dries Adriaens and colleagues in order to delineate the areas in Flanders where the Mean Lowest Watertable ('GLG') is located higher (less deep) than approx. 1.5 - 2 m below soil surface.
-This data source is needed to restrict the target population of several schemes in the groundwater compartiment.
+This data source is needed to restrict the target population of several MNE [monitoring](https://github.com/inbo/n2khab-monitoring) schemes in the groundwater compartiment.
 It is more specifically applied to restrict the 'locally groundwater dependent' types, i.e. to discard the sites without shallow groundwater.
 
 - Data and metadata are in [a GDrive folder](https://drive.google.com/drive/u/0/folders/1S9colwuaMNmB58u4RUnB0MqZLyIUZ9rT).
@@ -18,22 +18,23 @@ In this document, we append several layers to `shallowgroundwater`.
 The **aim** is to select areas which `shallowgroundwater` doesn't cover yet and where '(almost) everywhere groundwater dependent' types (here also called 'obliggwdep' types) are present.
 Such 'areas of interest' are e.g. anthropogenic soil type polygons, and a ring around the borders of `shallowgroundwater`.
 
-- In order not to exaggerate the extension of `shallowgroundwater`, we will subseqently limit those areas to _buffers (of `r params$buffer_obliggwdep` m) around habitatmap polygons with 'obliggwdep' types_ -- still clipping along the borders of the aforementioned areas.
+- In order not to exaggerate the extension of `shallowgroundwater`, we will subseqently limit those areas to _buffers (of `r params$buffer_obliggwdep` m) around habitatmap polygons with 'obliggwdep' types_ -- still subsequently clipping along the borders of the aforementioned areas.
 So in practice, we first select the habitatmap polygons with 'obliggwdep' types that intersect the areas of interest, we buffer them, and we clip the result along the areas of interest.
-  - The buffers around habitatmap polygons with 'obliggwdep' types are applied since it is expected that shallow groundwater (with potentially 'locally groundwater dependent' types) will occur in their vicinity.
+  - The buffers around habitatmap polygons with 'obliggwdep' types are applied since it is expected that shallow groundwater (with potentially 'locally groundwater dependent' types) will occur in the vicinity of those polygons.
 - In a next step, we want to add a _buffer of 200 m_ around the resulting polygons.
-This is done as a further means of conservative area selection: we rather need too much area than too little, given the ultimate aim of restricting target populations.
+This is done as a further means of conservative area selection: we rather need too much area than too little, for protection against over-restricting target populations.
 
 The areas of interest are:
 
-- all _anthropogenic soil type polygons_: i.e. where the `bsm_mo_soilunitype` column of the `soilmap_simple` data source starts with `O`;
+- all _anthropogenic soil type polygons_: i.e. where the `bsm_mo_soilunitype` column of the `soilmap_simple` data source starts with `"O"`;
 - a _ring around_ `shallowgroundwater` of 200 m wide.
 
 Regarding the anthropogenic soil type polygons, from earlier evaluation it appeared that the _narrow ones that contain 'obliggwdep' types_ are interesting as a whole.
-Hence we select them as a whole instead of selecting buffers around the habitatmap polygons with 'obliggwdep' types (before finally adding the buffer of 200 m to these soil type polygons):
+Hence we select them as a whole instead of selecting buffers around the habitatmap polygons with 'obliggwdep' types.
+And also in this case we end by finally adding a buffer of 200 m to these soil type polygons.
 
-- An appropriate algorithm had to be made that selects meaningful polygons - at first it resulted in complete cities meeting the narrowness requirement (since they are part of polygons with long, narrow parts).
-- Hence an additional condition was required: a sufficient amount of 'obliggwdep' type must be present in such polygons.
+- An appropriate algorithm had to be made that selects meaningful polygons - at first it resulted in complete cities meeting the narrowness requirement (since they are part of anthropogenic soil type polygons with long, narrow parts).
+- Hence an additional condition was required: a minimal amount of 'obliggwdep' type must be present in such polygons.
 
 Finally, we append the parts -- of all new layers -- that don't overlap `shallowgroundwater`, to `shallowgroundwater`.
 The resulting new version of `shallowgroundwater` is written here as **`sg_extended.gpkg`**.
@@ -47,7 +48,7 @@ Hence we will have three separate sources, which we will document as three extra
 Where an area overlapped between several of these sources, more than one column is set as `TRUE`.
 
 We do most geoprocessing tasks using `sf` (mostly using GEOS as backend).
-However in some cases we use `qgisprocess` (QGIS as backend) when the QGIS algorithm is either faster than or absent from `sf`.
+However in some cases we use `qgisprocess` (QGIS as backend) when the QGIS algorithm is either faster than, or absent from, `sf`.
 
 
 # Preparation
@@ -80,7 +81,7 @@ if (!dir.exists(sgpath) | list.files(sgpath) %>% length == 0) {
 
 Verification of several input data sets.
 
-Checksums (using default algorithm of `n2khab::checksum()`) of `shallowgroundwater`:
+Checksums of `shallowgroundwater` (using default algorithm of `n2khab::checksum()`):
 
 ```{r}
 checksums <- 
@@ -203,7 +204,7 @@ soil_anthrop <-
 
 The distribution of both calculated variables:
 
-```{r warning=FALSE}
+```{r warning=FALSE, out.width='70%'}
 soil_anthrop %>% 
   st_drop_geometry %>% 
   ggplot(aes(x = thinness)) + 
@@ -273,7 +274,7 @@ mapview(narrow_soilanthrop_with_obliggwdep,
 
 Resulting object: `narrow_soilanthrop_with_obliggwdep`.
 
-### Buffer `r params$buffer_obliggwdep` m around obliggwdep types, that are within 200 m of `shallowgroundwater`
+### Buffer `r params$buffer_obliggwdep` m around obliggwdep types, within a ring of 200 m around `shallowgroundwater`
 
 We will first create a ring around `shallowgroundwater` of 200 m width.
 
@@ -359,7 +360,7 @@ plan(multisession) # future kept here as demonstration
 ```
 
 
-```{r eval=!gpkg_buffered_obliggwdep_within_sg_ring_exists || params$rewrite_intermediate_files}
+```{r eval=!gpkg_buffered_obliggwdep_within_sg_ring_exists || params$rewrite_intermediate_files, warning=FALSE}
 # use of future unneeded in this case (runs quickly; however
 # hmt_pol_obliggwdep[sg_ring, ] takes very long)
 f <- future({
@@ -375,7 +376,7 @@ obliggwdep_sgring_qgis <- value(f, stdout = FALSE) # blocks calling R session if
 ```
 
 
-```{r eval=!gpkg_buffered_obliggwdep_within_sg_ring_exists || params$rewrite_intermediate_files}
+```{r eval=!gpkg_buffered_obliggwdep_within_sg_ring_exists || params$rewrite_intermediate_files, warning=FALSE}
 # use of future unneeded in this case (runs quickly)
 f <- future({
   elapsed <- 
@@ -463,18 +464,19 @@ st_layers(file.path(datapath, "new_areas.gpkg"))
 ```
 
 Each layer consists of just one Multipolygon.
-That is the result of unioning steps (`st_union()`; corresponding QGIS terminology is `native:aggregate`) in order to prevent overlapping polygons within the same layer, as a consequence of creating buffers.
+That is the result of unioning steps (obtained with `st_union()`; corresponding QGIS terminology is `native:aggregate`).
+The unioning is done in order to prevent overlapping polygons within the same layer as a consequence of creating buffers.
 
 ## Union the new zones (keeping intersections), subtract the original `shallowgroundwater` layer and append
 
-We extend `shallowgroundwater` as described in paragraph \@ref(method).
+We extend `shallowgroundwater` as described in section \@ref(method).
 
 ```{r include=FALSE}
 gpkg_sg_extended_exists <- file.exists(file.path(datapath, "sg_extended.gpkg"))
 ```
 
 
-```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists}
+```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists, warning=FALSE}
 # qgis_arguments("native:union")
 # use of future unneeded in this case (runs quickly)
 f <- future({
@@ -511,7 +513,7 @@ value(f, stdout = FALSE, signal = FALSE)$elapsed
 res_filepath2 <- value(f, stdout = FALSE)$result$OUTPUT %>% as.character
 ```
 
-```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists}
+```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists, warning=FALSE}
 f <- future({
   elapsed <- 
     system.time(
@@ -542,6 +544,8 @@ sg_extended <-
   ) %>% 
   st_sf(crs = 31370)
 ```
+
+Note that the attributes of the original data source need cleaning; `sg_extended` now has `r ncol(sg_extended) - 1` attribute columns.
 
 ```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists}
 system.time(

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -21,8 +21,6 @@ Such 'areas of interest' are e.g. anthropogenic soil type polygons and polygons 
 - In the case of anthropogenic and dune soil polygons, we will subseqently limit those areas to _buffers (of `r params$buffer_obliggwdep` m) around habitatmap polygons with 'obliggwdep' types_ -- still subsequently clipping along the borders of the aforementioned areas.
 So in practice, we first select the habitatmap polygons with 'obliggwdep' types that intersect the anthropogenic and dune soil polygons, we buffer them, and we clip the result along the areas of interest.
   - The buffers around habitatmap polygons with 'obliggwdep' types are applied since it is expected that shallow groundwater (with potentially 'locally groundwater dependent' types) will occur in the vicinity of those polygons.
-- In a next step, we want to add a _buffer of `r params$buffer_areas` m_ around the obtained polygons.
-This is done as a further means of conservative area selection: we rather need too much area than too little, for protection against over-restricting target populations.
 
 The areas of interest are:
 
@@ -36,13 +34,13 @@ Hence we select them as a whole instead of selecting buffers around the habitatm
 - Hence an additional condition was required: a minimal amount of 'obliggwdep' type must be present in such polygons.
 
 Finally, we stitch the parts.
-The resulting new version of `shallowgroundwater` is written here as **`sg2_extended_3.gpkg`**.
+The resulting new version of `shallowgroundwater` is written here as **`sg2_extended_4.gpkg`**.
 
-Hence we will have three separate sources, which we will document as three extra TRUE/FALSE column inside `sg2_extended_3.gpkg`:
+Hence we will have three separate sources, which we will document as three extra TRUE/FALSE column inside `sg2_extended_4.gpkg`:
 
-- `within_soilanthrop_plus_buffer`
-- `within_soildunes_plus_buffer`
-- `narrow_soilanthrop_plus_buffer`
+- `within_soilanthrop`
+- `within_soildunes`
+- `narrow_soilanthrop`
 
 Where an area overlapped between several of these sources, more than one column is set as `TRUE`.
 
@@ -364,7 +362,7 @@ mapview(narrow_soilanthrop_with_obliggwdep,
 
 Resulting object: `narrow_soilanthrop_with_obliggwdep`.
 
-## Add `r params$buffer_areas` m buffer to minimize false negatives
+## Combine the resulting layers in `new_areas.gpkg`
 
 ```{r include=FALSE}
 gpkg_newareas_exists <- 
@@ -377,33 +375,14 @@ plan(multisession) # future kept here as demonstration
 ```
 
 ```{r eval=!gpkg_newareas_exists || params$rewrite_intermediate_files, warning=FALSE}
-buffered_obliggwdep_within_soilanthrop_buff <- 
-  buffered_obliggwdep_within_soilanthrop %>% 
-  st_buffer(params$buffer_areas) %>% 
-  st_union %>% 
-  st_as_sf
-
-buffered_obliggwdep_within_soildunes_buff <- 
-  buffered_obliggwdep_within_soildunes %>% 
-  st_buffer(params$buffer_areas) %>% 
-  st_union %>% 
-  st_as_sf
-
-narrow_soilanthrop_with_obliggwdep_buff <-
-  narrow_soilanthrop_with_obliggwdep %>% 
-  select(-everything()) %>% 
-  st_buffer(params$buffer_areas) %>% 
-  st_union %>% 
-  st_as_sf
-
 if (gpkg_newareas_exists) unlink(file.path(datapath, "new_areas.gpkg"))
 
-list(buffered_obliggwdep_within_soilanthrop_buff =
-       buffered_obliggwdep_within_soilanthrop_buff,
-     buffered_obliggwdep_within_soildunes_buff =
-       buffered_obliggwdep_within_soildunes_buff,
-     narrow_soilanthrop_with_obliggwdep_buff =
-       narrow_soilanthrop_with_obliggwdep_buff) %>% 
+list(buffered_obliggwdep_within_soilanthrop =
+       buffered_obliggwdep_within_soilanthrop,
+     buffered_obliggwdep_within_soildunes =
+       buffered_obliggwdep_within_soildunes,
+     narrow_soilanthrop_with_obliggwdep =
+       narrow_soilanthrop_with_obliggwdep) %>% 
   walk2(names(.),
         ~write_sf(.x,
                   dsn = file.path(datapath, "new_areas.gpkg"),
@@ -435,7 +414,7 @@ The unioning is done in order to prevent overlapping polygons within the same la
 We extend `shallowgroundwater` as described in section \@ref(method).
 
 ```{r include=FALSE}
-gpkg_sg_extended_exists <- file.exists(file.path(datapath, "sg2_extended_3.gpkg"))
+gpkg_sg_extended_exists <- file.exists(file.path(datapath, "sg2_extended_4.gpkg"))
 ```
 
 ```{r intersecting, eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists, warning=FALSE}
@@ -446,11 +425,15 @@ f <- future({
     system.time(
       result <- qgis_run_algorithm("native:union",
                                    INPUT = 
-                                     buffered_obliggwdep_within_soilanthrop_buff %>% 
-                                     mutate(within_soilanthrop_plus_buffer = TRUE),
+                                     buffered_obliggwdep_within_soilanthrop %>% 
+                                     st_union %>% 
+                                     st_as_sf %>% 
+                                     mutate(within_soilanthrop = TRUE),
                                    OVERLAY = 
-                                     narrow_soilanthrop_with_obliggwdep_buff %>% 
-                                     mutate(narrow_soilanthrop_plus_buffer = TRUE))
+                                     narrow_soilanthrop_with_obliggwdep %>% 
+                                     st_union %>% 
+                                     st_as_sf %>% 
+                                     mutate(narrow_soilanthrop = TRUE))
     )
   list(result = result, elapsed = elapsed)
 }, seed = NULL)
@@ -464,8 +447,10 @@ f <- future({
       result <- qgis_run_algorithm("native:union",
                                    INPUT = res_filepath,
                                    OVERLAY = 
-                                     buffered_obliggwdep_within_soildunes_buff %>% 
-                                     mutate(within_soildunes_plus_buffer = TRUE))
+                                     buffered_obliggwdep_within_soildunes %>% 
+                                     st_union %>% 
+                                     st_as_sf %>% 
+                                     mutate(within_soildunes = TRUE))
     )
   list(result = result, elapsed = elapsed)
 }, seed = NULL)
@@ -499,7 +484,7 @@ value(f, stdout = FALSE, signal = FALSE)$elapsed
 res_filepath2 <- value(f, stdout = FALSE)$result$OUTPUT %>% as.character
 ```
 
-The result is written as `sg2_extended_3.gpkg`.
+The result is written as `sg2_extended_4.gpkg`.
 
 ```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists}
 sg_extended <- 
@@ -511,7 +496,7 @@ sg_extended <-
 ```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists}
 system.time(
 st_write(sg_extended,
-         file.path(datapath, "sg2_extended_3.gpkg"),
+         file.path(datapath, "sg2_extended_4.gpkg"),
          layer = "sg_extended",
          delete_dsn = TRUE,
          quiet = TRUE)

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -390,13 +390,15 @@ gpkg_newareas_exists <-
 buffered_obliggwdep_within_soilanthrop_buff200 <- 
   buffered_obliggwdep_within_soilanthrop %>% 
   st_buffer(200) %>% 
-  st_union
+  st_union %>% 
+  st_as_sf
 
 narrow_soilanthrop_with_obliggwdep_buff200 <-
   narrow_soilanthrop_with_obliggwdep %>% 
   select(-everything()) %>% 
   st_buffer(200) %>% 
-  st_union
+  st_union %>% 
+  st_as_sf
 
 buffered_obliggwdep_within_sg_ring_buff200 <- 
   buffered_obliggwdep_within_sg_ring %>% 

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -87,6 +87,11 @@ checksums %>%
 ```
 
 ```{r}
+if (!file.exists(file.path(sgpath, "shallowgroundwater.gpkg"))) {
+  stop("It seems that you have manually put a file inside ",
+       sgpath,
+       "\nMake sure that you name this file as shallowgroundwater.gpkg !")
+}
 if (any(checksums != 
         c(shallowgroundwater.gpkg = "0052a67f88296b60"))
 ) stop("Beware, your version of shallowgroundwater is not the one for which this code was intended!")

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -417,7 +417,7 @@ We extend `shallowgroundwater` as described in section \@ref(method).
 gpkg_sg_extended_exists <- file.exists(file.path(datapath, "sg2_extended_3.gpkg"))
 ```
 
-```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists, warning=FALSE}
+```{r intersecting, eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists, warning=FALSE}
 # qgis_arguments("native:union")
 # use of future unneeded in this case (runs quickly)
 f <- future({

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -378,11 +378,17 @@ plan(multisession) # future kept here as demonstration
 if (gpkg_newareas_exists) unlink(file.path(datapath, "new_areas.gpkg"))
 
 list(buffered_obliggwdep_within_soilanthrop =
-       buffered_obliggwdep_within_soilanthrop,
+       buffered_obliggwdep_within_soilanthrop %>% 
+       st_union %>% 
+       st_as_sf,
      buffered_obliggwdep_within_soildunes =
-       buffered_obliggwdep_within_soildunes,
+       buffered_obliggwdep_within_soildunes %>% 
+       st_union %>% 
+       st_as_sf,
      narrow_soilanthrop_with_obliggwdep =
-       narrow_soilanthrop_with_obliggwdep) %>% 
+       narrow_soilanthrop_with_obliggwdep %>% 
+       st_union %>% 
+       st_as_sf) %>% 
   walk2(names(.),
         ~write_sf(.x,
                   dsn = file.path(datapath, "new_areas.gpkg"),
@@ -426,13 +432,9 @@ f <- future({
       result <- qgis_run_algorithm("native:union",
                                    INPUT = 
                                      buffered_obliggwdep_within_soilanthrop %>% 
-                                     st_union %>% 
-                                     st_as_sf %>% 
                                      mutate(within_soilanthrop = TRUE),
                                    OVERLAY = 
                                      narrow_soilanthrop_with_obliggwdep %>% 
-                                     st_union %>% 
-                                     st_as_sf %>% 
                                      mutate(narrow_soilanthrop = TRUE))
     )
   list(result = result, elapsed = elapsed)
@@ -448,8 +450,6 @@ f <- future({
                                    INPUT = res_filepath,
                                    OVERLAY = 
                                      buffered_obliggwdep_within_soildunes %>% 
-                                     st_union %>% 
-                                     st_as_sf %>% 
                                      mutate(within_soildunes = TRUE))
     )
   list(result = result, elapsed = elapsed)

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -1,0 +1,428 @@
+# Introduction
+
+## Current, intermediate state of the `shallowgroundwater` data source
+
+A `shallowgroundwater` data source was prepared by Dries Adriaens and colleagues in order to delineate the areas in Flanders where the Mean Lowest Watertable ('GLG') is located higher (less deep) than approx. 1.5 - 2 m below soil surface.
+This data source is needed to restrict the target population of several schemes in the groundwater compartiment.
+It is more specifically applied to restrict the 'locally groundwater dependent' types, i.e. to discard the sites without shallow groundwater.
+
+- Data and metadata are in [a GDrive folder](https://drive.google.com/drive/u/0/folders/1S9colwuaMNmB58u4RUnB0MqZLyIUZ9rT).
+- More info about checking the data source: see <https://github.com/inbo/n2khab-mne-design/pull/74> and links therein.
+
+Based on an evaluation that uses the '(almost) everywhere groundwater dependent' types, the current state does not yet cover a significant proportion of those types.
+Hence, the area it covers needs to be made broader.
+
+## Aim
+
+In this document, we generate several sets of _extra polygons_ to be added to shallowgroundwater:
+
+- _within_ anthropogenic soil types (using the `bsm_mo_soilunitype` column of the `soilmap_simple` data source): buffers of 500 m around the '(almost) everywhere groundwater dependent' types (here also called 'obliggwdep' types);
+- for narrow anthropogenic soil type polygons: if they contain 'obliggwdep' types, then add them as a whole.
+An appropriate algorithm has to be made that selects meaningful polygons - often it appears that complete cities would meet the foregoing requirement, so a sufficient amount of 'obliggwdep' type will need to be present in such polygons;
+- buffering `shallowgroundwater`
+
+# Preparation
+
+## Data setup and checks
+
+```{r}
+local_root <- find_root(has_file("update_shallowgroundwater.Rproj"))
+datapath <- file.path(local_root, "data")
+if (!dir.exists(datapath)) dir.create(datapath)
+sgpath <- find_root_file("n2khab_data/10_raw/shallowgroundwater", 
+                            criterion = has_dir("n2khab_data"))
+
+if (!dir.exists(sgpath) | list.files(sgpath) %>% length == 0) {
+  dir.create(sgpath)
+  drive_auth(email = TRUE)
+  # downloads "ZonesOndiepGrondwater_2019-03-29.zip":
+  as_id("1n_LyvRDDzL3hraoMWf_pBhabTYiWsiD0") %>% 
+    drive_download(file.path(tempdir(), "file.zip"), 
+                   overwrite = TRUE)
+  unzip(file.path(tempdir(), "file.zip"), 
+        exdir = sgpath)
+  filenames <- list.files(sgpath, full.names = TRUE)
+  file.rename(filenames,
+              str_replace(filenames, 
+                          "ZonesOndiepGrondwater", 
+                          "shallowgroundwater"))
+}
+```
+
+Verification of several input data sets.
+
+```{r}
+checksums <- 
+  list.files(sgpath, full.names = TRUE) %>% 
+  checksum
+checksums %>% 
+  as.matrix
+```
+
+```{r}
+if (any(checksums != 
+        c(shallowgroundwater.cpg = "a0915c78be995614",
+          shallowgroundwater.dbf = "c4ceda6d9466bd89", 
+          shallowgroundwater.qpj = "853f02064884203e",
+          shallowgroundwater.sbn = "cb0c0bb2565829ff", 
+          shallowgroundwater.sbx = "9419203dc2909044",
+          shallowgroundwater.shp = "5cf8969daa942dec", 
+          shallowgroundwater.shp.xml = "6df16307066eec5e",
+          shallowgroundwater.shx = "bc582622278dba1c"))
+) warning("Beware, your version of shallowgroundwater is not the one for which this code was intended!")
+```
+
+```{r}
+sspath <- find_root_file("n2khab_data/20_processed/soilmap_simple/soilmap_simple.gpkg", 
+                            criterion = has_dir("n2khab_data"))
+if (!file.exists(sspath)) stop("Please organize soilmap_simple location. See e.g. https://inbo.github.io/n2khab/articles/v022_example.html")
+if (checksum(sspath) != "9f4204b476506031") stop("Incorrect soilmap_simple version.")
+
+hmtpath <- find_root_file("n2khab_data/20_processed/habitatmap_terr/habitatmap_terr.gpkg", 
+                            criterion = has_dir("n2khab_data"))
+if (!file.exists(hmtpath)) stop("Please organize habitatmap_terr location. See https://inbo.github.io/n2khab")
+assertthat::assert_that(checksum(hmtpath) == "72d3144016e816ed",
+                        msg = "Incorrect habitatmap_terr version.")
+```
+
+Reading data sets.
+
+```{r}
+soilmap <- read_soilmap()
+```
+
+```{r include=FALSE}
+gpkg_sg_exists <- 
+  file.exists(file.path(datapath, 
+                        "sg_repairedgeom.gpkg"))
+```
+
+```{r eval=!gpkg_sg_exists}
+sg <- read_sf(sgpath, crs = 31370)
+```
+
+```{r eval=FALSE, echo=FALSE}
+read_soilmap(use_processed = FALSE) %>% 
+  st_drop_geometry %>% 
+  filter(str_sub(bsm_mo_soilunitype, 1, 1) == "O") %>% 
+  count(bsm_mo_soilunitype, 
+           bsm_soilseries, 
+           bsm_soilseries_explan,
+           bsm_ge_series,
+           bsm_ge_series_explan)
+```
+
+## Preparing derived input data
+
+Constructing the geospatial and attribute data of `habitatmap_terr` polygons that contain 'obliggwdep' types, relevant in the MNE monitoring programme.
+
+```{r message = FALSE, warning = FALSE}
+scheme_types_mne_expanded <-
+  read_scheme_types(extended = TRUE) %>%
+  filter(programme == "MNE") %>%
+  distinct(scheme, type) %>%
+  group_by(scheme) %>%
+  expand_types %>%
+  ungroup
+types_obliggwdep <-
+  read_types() %>% 
+  filter(groundw_dep == "GD2") %>%
+  select(type) %>% 
+  # following step does 2 things: 
+  # - drop 6 (main) type codes that don't appear in habitatmap_terr
+  # - avoid 7110, which we don't recognize within MNE (one location in habitatmap_terr)
+  semi_join(scheme_types_mne_expanded, by = "type")
+hmt <- read_habitatmap_terr(keep_aq_types = FALSE)
+hmt_occ_obliggwdep <- 
+  hmt$habitatmap_terr_types %>% 
+  semi_join(types_obliggwdep,  
+            by = "type")
+hmt_pol_obliggwdep <- 
+  hmt$habitatmap_terr_polygons %>% 
+  select(polygon_id, description_orig) %>% 
+  semi_join(hmt_occ_obliggwdep,
+            by = "polygon_id")
+st_agr(hmt_pol_obliggwdep) <- "constant"
+```
+
+Creating a geospatial object of anthropogenic soil type polygons, and calculate a property 'thinness' (from [here](https://tereshenkov.wordpress.com/2014/04/08/fighting-sliver-polygons-in-arcgis-thinness-ratio/)) - lower means more narrow - as well as the areal fraction occupied by `habitatmap_terr` polygons having 'obliggwdep' types.
+
+```{r}
+soil_anthrop <- 
+  soilmap %>% 
+  filter(str_sub(bsm_mo_soilunitype, 1, 1) == "O") %>% 
+  select(bsm_poly_id, bsm_mo_soilunitype) %>% 
+  mutate(perimeter = lwgeom::st_perimeter(.),
+         area = st_area(.),
+         thinness =  4 * pi * (area / perimeter ^2) %>% drop_units()) %>% 
+  st_make_valid()
+st_agr(soil_anthrop) <- "constant"
+soil_anthrop_occupied <- 
+  soil_anthrop %>% 
+  st_intersection(hmt_pol_obliggwdep) %>% 
+  mutate(subarea = st_area(.)) %>% 
+  st_drop_geometry %>% 
+  group_by(bsm_poly_id) %>% 
+  summarise(obliggwdep_pol_frac = drop_units(sum(subarea) / first(area)))
+soil_anthrop <- 
+  soil_anthrop %>% 
+  left_join(soil_anthrop_occupied,
+            by = "bsm_poly_id")
+```
+
+The distribution of both calculated variables:
+
+```{r warning=FALSE}
+soil_anthrop %>% 
+  st_drop_geometry %>% 
+  ggplot(aes(x = thinness)) + 
+  geom_histogram(binwidth = 0.01, fill = "white", colour = "grey70")
+soil_anthrop %>% 
+  st_drop_geometry %>% 
+  ggplot(aes(x = obliggwdep_pol_frac)) + 
+  geom_histogram(binwidth = 0.01, fill = "white", colour = "grey70")
+```
+
+# Execution
+
+## Buffer 500 m around obliggwdep types, within `soil_anthrop`
+
+We create this geospatial object and also write it as a GPKG file, since the calculation takes several minutes.
+
+```{r include=FALSE}
+gpkg_exists <- 
+  file.exists(file.path(datapath, 
+                        "buffered_obliggwdep_within_soilanthrop.gpkg"))
+```
+
+```{r eval=!gpkg_exists}
+# following step takes several minutes!
+buffered_obliggwdep_within_soilanthrop <-
+  hmt_pol_obliggwdep[soil_anthrop, ] %>% 
+  st_make_valid(.) %>% 
+  st_buffer(500) %>% 
+  st_union() %>% 
+  st_intersection(soil_anthrop)
+st_write(buffered_obliggwdep_within_soilanthrop, 
+         file.path(datapath, 
+                   "buffered_obliggwdep_within_soilanthrop.gpkg"),
+         delete_dsn = TRUE)
+```
+
+```{r eval=gpkg_exists, include = FALSE}
+buffered_obliggwdep_within_soilanthrop <- 
+  read_sf(file.path(datapath, 
+                    "buffered_obliggwdep_within_soilanthrop.gpkg"))
+```
+
+Resulting object: `buffered_obliggwdep_within_soilanthrop`.
+
+## Narrow anthropogenic soil polygons with 'obliggwdep' types, buffered by 100 m
+
+After several iterations, the below used conditions on `thinness` and `obliggwdep_pol_frac` appeared satisfying.
+
+```{r out.width='800px', out.height='500px'}
+narrow_soilanthrop_with_obliggwdep <- 
+  soil_anthrop %>% 
+  filter(thinness < 0.15,
+         obliggwdep_pol_frac > 0.04)
+mapview(narrow_soilanthrop_with_obliggwdep,
+        zcol = "thinness",
+        color = "pink3",
+        lwd = 2)
+```
+
+Resulting object: `narrow_soilanthrop_with_obliggwdep`.
+
+## Buffer 200 m around `buffered_obliggwdep_within_soilanthrop` and `narrow_soilanthrop_with_obliggwdep`
+
+```{r}
+buffered_obliggwdep_within_soilanthrop_buff200 <- 
+  buffered_obliggwdep_within_soilanthrop %>% 
+  st_buffer(200)
+```
+
+```{r}
+narrow_soilanthrop_with_obliggwdep_buff200 <- 
+  narrow_soilanthrop_with_obliggwdep %>% 
+  st_buffer(200)
+```
+
+
+## Buffer 500 m around obliggwdep types, that are within 200 m of `shallowgroundwater`
+
+We need to do this in GRASS because of the large `shallowgroundwater` input.
+
+```{r}
+grasspath <- file.path(datapath, "grass")
+grass_exists <- file.exists(file.path(grasspath, 
+                                      "PERMANENT/PROJ_INFO"))
+if (!dir.exists(grasspath)) dir.create(grasspath)
+```
+
+
+```{r results="hide"}
+# CREATE OR LINK to a permanent GRASS location
+initGRASS(gisBase = gisbase_grass,
+          gisDbase = datapath,
+          home = grasspath,
+          location = "grass",
+          mapset = "PERMANENT", 
+          override = TRUE)
+if (!grass_exists) {
+    execGRASS("g.proj", c("c", "quiet"), 
+              epsg = 31370)
+}
+# gmeta()
+use_sf()
+```
+
+
+```{r}
+stopifnot(file.exists(file.path(grasspath, 
+                                "PERMANENT/PROJ_INFO")))
+```
+
+```{r warning=FALSE, results="hide", eval=!grass_exists}
+execGRASS("v.in.ogr",
+          input = normalizePath(file.path(fileman_up("n2khab_data"),
+                                          "10_raw/shallowgroundwater")),
+          output = "sg",
+          flags = c("o", # assume CRS is same as from GRASS, i.e. set CRS as EPSG:31370
+                    "overwrite")
+          )
+```
+
+```{r}
+writeVECT(hmt_pol_obliggwdep, "hmt_pol_obliggwdep")
+```
+
+```{r eval=!gpkg_sg_exists}
+sg_repairedgeom <- 
+  st_make_valid(sg) %>% 
+  st_cast("MULTIPOLYGON")
+st_write(sg_repairedgeom,
+         file.path(datapath, 
+                   "sg_repairedgeom.gpkg"),
+         delete_dsn = TRUE)
+```
+
+```{r eval=gpkg_sg_exists, include=FALSE}
+sg_repairedgeom <- 
+  read_sf(file.path(datapath, 
+                    "sg_repairedgeom.gpkg"))
+```
+
+```{r include=FALSE}
+gpkg_sg_buff_exists <- 
+  file.exists(file.path(datapath, 
+                        "sg_buff.gpkg"))
+```
+
+
+```{r eval=!gpkg_sg_buff_exists}
+sg_buff <- 
+  sg_repairedgeom %>% 
+  st_buffer(200) %>% 
+  st_cast("MULTIPOLYGON")
+sg_buff %>% 
+  st_write(file.path(datapath, 
+                     "sg_buff.gpkg"),
+           delete_dsn = TRUE)
+```
+
+```{r eval=gpkg_sg_buff_exists, include=FALSE}
+sg_buff <- 
+  read_sf(file.path(datapath, 
+                    "sg_buff.gpkg"))
+```
+
+```{r}
+# qgis_algorithms() %>% filter(str_detect(algorithm, "diff"))
+# qgis_show_help("native:difference")
+hmt_pol_obliggwdep %>% 
+  st_make_valid %>% 
+  st_write(file.path(datapath, 
+                     "hmt_pol_obliggwdep.gpkg"),
+           delete_dsn = TRUE)
+sg_ring <- 
+  qgis_run_algorithm("native:difference",
+                     INPUT = file.path(datapath, 
+                                       "sg_buff.gpkg"),
+                     OVERLAY = file.path(datapath, 
+                                         "sg_repairedgeom.gpkg"))
+system.time(
+  sg_ring <- 
+    qgis_run_algorithm("grass7:v.overlay",
+                       ainput = file.path(datapath, 
+                                          "sg_buff.gpkg"),
+                       binput = file.path(datapath, 
+                                          "sg_repairedgeom.gpkg"),
+                       operator = "2")
+)
+```
+
+
+```{r}
+execGRASS("v.in.ogr",
+          input = file.path(datapath, "sg_repairedgeom.gpkg"),
+          output = "sg_repairedgeom",
+          flags = "overwrite")
+execGRASS("v.in.ogr",
+          input = file.path(datapath, "sg_buff.gpkg"),
+          output = "sg_buff",
+          flags = c("c", "overwrite"))
+```
+
+
+```{r}
+system.time({
+sg_union <-
+  sg_repairedgeom %>%
+  st_union()
+sg_buff2 <-
+  sg_union %>%
+  st_buffer(200)
+sg_ring <- 
+  st_difference(sg_buff2, sg_union)
+})
+#     user   system  elapsed 
+# 2044.543    0.000 2045.678 
+st_write(sg_ring, 
+         file.path(datapath, 
+                   "sg_ring.gpkg"),
+         delete_dsn = TRUE)
+```
+
+```{r eval=!gpkg_exists}
+# following step takes several minutes!
+system.time(
+buffered_obliggwdep_nearsg <-
+  hmt_pol_obliggwdep[sg_ring, ] %>% 
+  st_make_valid(.) %>% 
+  st_buffer(500) %>% 
+  st_union()
+)
+st_write(buffered_obliggwdep_nearsg, 
+         file.path(datapath, 
+                   "buffered_obliggwdep_nearsg.gpkg"),
+         delete_dsn = TRUE)
+```
+
+
+```{r}
+execshell("v.overlay ainput=sg_buff binput=sg_repairedgeom operator=not output=sg_ring")
+```
+
+```{r}
+library(future)
+plan(multisession, workers = 6)
+hmt_sel %<-% {
+  hmt_pol_obliggwdep[sg_ring, ]
+}
+hmt_sel %<-% hmt_pol_obliggwdep[sg_ring, ] %packages% "sf"
+f <- futureOf(hmt_sel)
+resolved(f)
+value(f)
+```
+

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -239,21 +239,6 @@ mapview(narrow_soilanthrop_with_obliggwdep,
 
 Resulting object: `narrow_soilanthrop_with_obliggwdep`.
 
-## Buffer 200 m around `buffered_obliggwdep_within_soilanthrop` and `narrow_soilanthrop_with_obliggwdep`
-
-```{r}
-buffered_obliggwdep_within_soilanthrop_buff200 <- 
-  buffered_obliggwdep_within_soilanthrop %>% 
-  st_buffer(200)
-```
-
-```{r}
-narrow_soilanthrop_with_obliggwdep_buff200 <- 
-  narrow_soilanthrop_with_obliggwdep %>% 
-  st_buffer(200)
-```
-
-
 ## Buffer 500 m around obliggwdep types, that are within 200 m of `shallowgroundwater`
 
 
@@ -313,26 +298,124 @@ buffered_obliggwdep_nearsg <-
   st_buffer(500) %>% 
   st_union()
 )
-st_write(buffered_obliggwdep_nearsg, 
+```
+
+```{r include=FALSE}
+gpkg_buffered_obliggwdep_within_sg_ring_exists <- 
+  file.exists(file.path(datapath, 
+                        "buffered_obliggwdep_within_sg_ring.gpkg"))
+```
+
+```{r eval=!gpkg_buffered_obliggwdep_within_sg_ring_exists}
+# qgis_algorithms() %>% filter(str_detect(algorithm, "extract"))
+# qgis_show_help("native:extractbylocation")
+hmt_pol_obliggwdep %>% 
+  st_make_valid %>% 
+  st_write(file.path(datapath, 
+                     "hmt_pol_obliggwdep.gpkg"),
+           delete_dsn = TRUE)
+```
+
+
+```{r eval=!gpkg_buffered_obliggwdep_within_sg_ring_exists}
+plan(multisession) # future kept here as demonstration
+```
+
+
+```{r eval=!gpkg_buffered_obliggwdep_within_sg_ring_exists}
+# use of future unneeded in this case (runs quickly; however
+# hmt_pol_obliggwdep[sg_ring, ] takes very long)
+f <- future({
+  qgis_run_algorithm("native:extractbylocation",
+                       INPUT = file.path(datapath, 
+                                         "hmt_pol_obliggwdep.gpkg"),
+                       PREDICATE = 0,
+                       INTERSECT = file.path(datapath, 
+                                             "sg_ring.gpkg"))
+}, seed = NULL)
+# resolved(f)
+obliggwdep_sgring_qgis <- value(f, stdout = FALSE) # blocks calling R session if !resolved(f)
+```
+
+
+```{r eval=!gpkg_buffered_obliggwdep_within_sg_ring_exists}
+# use of future unneeded in this case (runs quickly
+f <- future({
+  elapsed <- 
+    system.time(
+      result <-
+        obliggwdep_sgring_qgis$OUTPUT %>% 
+        read_sf %>% 
+        st_buffer(500) %>% 
+        st_union() %>% 
+        st_intersection(sg_ring)
+    )
+  list(result = result, elapsed = elapsed)
+}, seed = NULL)
+# resolved(f)
+value(f, stdout = FALSE)$elapsed
+buffered_obliggwdep_within_sg_ring <- value(f, stdout = FALSE)$result
+st_write(buffered_obliggwdep_within_sg_ring, 
          file.path(datapath, 
-                   "buffered_obliggwdep_nearsg.gpkg"),
+                   "buffered_obliggwdep_within_sg_ring.gpkg"),
          delete_dsn = TRUE)
 ```
 
 
 ```{r}
-execshell("v.overlay ainput=sg_buff binput=sg_repairedgeom operator=not output=sg_ring")
+plan(sequential)
 ```
 
-```{r}
-library(future)
-plan(multisession, workers = 6)
-hmt_sel %<-% {
-  hmt_pol_obliggwdep[sg_ring, ]
-}
-hmt_sel %<-% hmt_pol_obliggwdep[sg_ring, ] %packages% "sf"
-f <- futureOf(hmt_sel)
-resolved(f)
-value(f)
+
+```{r eval=gpkg_buffered_obliggwdep_within_sg_ring_exists, include=FALSE}
+buffered_obliggwdep_within_sg_ring <- 
+  read_sf(file.path(datapath, 
+                    "buffered_obliggwdep_within_sg_ring.gpkg"))
 ```
 
+Resulting object: `buffered_obliggwdep_within_sg_ring`.
+
+
+## Buffer 200 m around `buffered_obliggwdep_within_soilanthrop`, `narrow_soilanthrop_with_obliggwdep` and `buffered_obliggwdep_within_sg_ring`
+
+```{r include=FALSE}
+gpkg_newareas_exists <- 
+  file.exists(file.path(datapath, 
+                        "new_areas.gpkg"))
+```
+
+```{r eval=!gpkg_newareas_exists}
+buffered_obliggwdep_within_soilanthrop_buff200 <- 
+  buffered_obliggwdep_within_soilanthrop %>% 
+  st_buffer(200) %>% 
+  st_cast("MULTIPOLYGON")
+
+narrow_soilanthrop_with_obliggwdep_buff200 <- 
+  narrow_soilanthrop_with_obliggwdep %>% 
+  select(-everything()) %>% 
+  st_buffer(200)
+
+buffered_obliggwdep_within_sg_ring_buff200 <- 
+  buffered_obliggwdep_within_sg_ring %>% 
+  st_buffer(200)
+
+list(buffered_obliggwdep_within_soilanthrop_buff200 =
+       buffered_obliggwdep_within_soilanthrop_buff200,
+     narrow_soilanthrop_with_obliggwdep_buff200 =
+       narrow_soilanthrop_with_obliggwdep_buff200,
+     buffered_obliggwdep_within_sg_ring_buff200 =
+       buffered_obliggwdep_within_sg_ring_buff200) %>% 
+  walk2(names(.),
+        ~st_write(.x,
+                  dsn = file.path(datapath, "new_areas.gpkg"),
+                  layer = .y))
+```
+
+```{r eval=gpkg_newareas_exists, include=FALSE}
+walk(1:3, function(i) {
+  layername <- st_layers(file.path(datapath, "new_areas.gpkg"))$name[i]
+  assign(layername,
+         read_sf(file.path(datapath, "new_areas.gpkg"),
+                 layer = layername))
+})
+```

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -33,10 +33,15 @@ Hence we select them as a whole instead of selecting buffers around the habitatm
 - An appropriate algorithm had to be made that selects meaningful polygons - at first it resulted in complete cities meeting the narrowness requirement (since they are part of anthropogenic soil type polygons with long, narrow parts).
 - Hence an additional condition was required: a minimal amount of 'obliggwdep' type must be present in such polygons.
 
-Finally, we stitch the parts.
-The resulting new version of `shallowgroundwater` is written here as **`sg2_extended_4.gpkg`**.
+```{r}
+output_filename <- params$output_filename
+```
 
-Hence we will have three separate sources, which we will document as three extra TRUE/FALSE column inside `sg2_extended_4.gpkg`:
+
+Finally, we stitch the parts.
+The resulting new version of `shallowgroundwater` is written here as **``r output_filename``**.
+
+Hence we will have three separate sources, which we will document as three extra TRUE/FALSE column inside ``r output_filename``:
 
 - `within_soilanthrop`
 - `within_soildunes`
@@ -420,7 +425,7 @@ The unioning is done in order to get the simplest possible intersection result i
 We extend `shallowgroundwater` as described in section \@ref(method).
 
 ```{r include=FALSE}
-gpkg_sg_extended_exists <- file.exists(file.path(datapath, "sg2_extended_4.gpkg"))
+gpkg_sg_extended_exists <- file.exists(file.path(datapath, output_filename))
 ```
 
 ```{r intersecting, eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists, warning=FALSE}
@@ -484,7 +489,7 @@ value(f, stdout = FALSE, signal = FALSE)$elapsed
 res_filepath2 <- value(f, stdout = FALSE)$result$OUTPUT %>% as.character
 ```
 
-The result is written as `sg2_extended_4.gpkg`.
+The result is written as ``r output_filename``.
 
 ```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists}
 sg_extended <- 
@@ -496,7 +501,7 @@ sg_extended <-
 ```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists}
 system.time(
 st_write(sg_extended,
-         file.path(datapath, "sg2_extended_4.gpkg"),
+         file.path(datapath, output_filename),
          layer = "sg_extended",
          delete_dsn = TRUE,
          quiet = TRUE)

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -205,7 +205,7 @@ buffered_obliggwdep_within_soilanthrop <-
   st_buffer(500) %>% 
   st_union() %>% 
   st_intersection(soil_anthrop)
-st_write(buffered_obliggwdep_within_soilanthrop, 
+write_sf(buffered_obliggwdep_within_soilanthrop, 
          file.path(datapath, 
                    "buffered_obliggwdep_within_soilanthrop.gpkg"),
          delete_dsn = TRUE)
@@ -248,7 +248,7 @@ Resulting object: `narrow_soilanthrop_with_obliggwdep`.
 sg_repairedgeom <- 
   st_make_valid(sg) %>% 
   st_cast("MULTIPOLYGON")
-st_write(sg_repairedgeom,
+write_sf(sg_repairedgeom,
          file.path(datapath, 
                    "sg_repairedgeom.gpkg"),
          delete_dsn = TRUE)
@@ -279,7 +279,7 @@ sg_ring <-
 })
 #     user   system  elapsed 
 # 2044.543    0.000 2045.678 
-st_write(sg_ring, 
+write_sf(sg_ring, 
          file.path(datapath, 
                    "sg_ring.gpkg"),
          delete_dsn = TRUE)
@@ -313,7 +313,7 @@ gpkg_buffered_obliggwdep_within_sg_ring_exists <-
 # qgis_show_help("native:extractbylocation")
 hmt_pol_obliggwdep %>% 
   st_make_valid %>% 
-  st_write(file.path(datapath, 
+  write_sf(file.path(datapath, 
                      "hmt_pol_obliggwdep.gpkg"),
            delete_dsn = TRUE)
 ```
@@ -357,7 +357,7 @@ f <- future({
 # resolved(f)
 value(f, stdout = FALSE)$elapsed
 buffered_obliggwdep_within_sg_ring <- value(f, stdout = FALSE)$result
-st_write(buffered_obliggwdep_within_sg_ring, 
+write_sf(buffered_obliggwdep_within_sg_ring, 
          file.path(datapath, 
                    "buffered_obliggwdep_within_sg_ring.gpkg"),
          delete_dsn = TRUE)
@@ -411,7 +411,7 @@ list(buffered_obliggwdep_within_soilanthrop_buff200 =
      buffered_obliggwdep_within_sg_ring_buff200 =
        buffered_obliggwdep_within_sg_ring_buff200) %>% 
   walk2(names(.),
-        ~st_write(.x,
+        ~write_sf(.x,
                   dsn = file.path(datapath, "new_areas.gpkg"),
                   layer = .y))
 ```

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -413,7 +413,7 @@ st_layers(file.path(datapath, "new_areas.gpkg"))
 
 Each layer consists of just one Multipolygon.
 That is the result of unioning steps (obtained with `st_union()`; corresponding QGIS terminology is `native:aggregate`).
-The unioning is done in order to prevent overlapping polygons within the same layer as a consequence of creating buffers.
+The unioning is done in order to get the simplest possible intersection result in the next step.
 
 ## Union the new zones (keeping intersections)
 

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -16,17 +16,18 @@ Hence, the area it covers needs to be made broader.
 
 In this document, we append several layers to `shallowgroundwater`.
 The **aim** is to select areas which `shallowgroundwater` doesn't cover yet and where '(almost) everywhere groundwater dependent' types (here also called 'obliggwdep' types) are present.
-Such 'areas of interest' are e.g. anthropogenic soil type polygons.
+Such 'areas of interest' are e.g. anthropogenic soil type polygons and polygons with 'dunes' as soil texture type.
 
-- In the case of anthropogenic soil type polygons, we will subseqently limit those areas to _buffers (of `r params$buffer_obliggwdep` m) around habitatmap polygons with 'obliggwdep' types_ -- still subsequently clipping along the borders of the aforementioned areas.
-So in practice, we first select the habitatmap polygons with 'obliggwdep' types that intersect the anthropogenic soil type polygons, we buffer them, and we clip the result along the areas of interest.
+- In the case of anthropogenic and dune soil polygons, we will subseqently limit those areas to _buffers (of `r params$buffer_obliggwdep` m) around habitatmap polygons with 'obliggwdep' types_ -- still subsequently clipping along the borders of the aforementioned areas.
+So in practice, we first select the habitatmap polygons with 'obliggwdep' types that intersect the anthropogenic and dune soil polygons, we buffer them, and we clip the result along the areas of interest.
   - The buffers around habitatmap polygons with 'obliggwdep' types are applied since it is expected that shallow groundwater (with potentially 'locally groundwater dependent' types) will occur in the vicinity of those polygons.
 - In a next step, we want to add a _buffer of `r params$buffer_areas` m_ around the obtained polygons.
 This is done as a further means of conservative area selection: we rather need too much area than too little, for protection against over-restricting target populations.
 
 The areas of interest are:
 
-- all _anthropogenic soil type polygons_: i.e. where the `bsm_mo_soilunitype` column of the `soilmap_simple` data source starts with `"O"`.
+- all _anthropogenic soil type polygons_: i.e. where the `bsm_mo_soilunitype` column of the `soilmap_simple` data source starts with `"O"`;
+- all _dune texture polygons_: i.e. where the `bsm_mo_tex` column equals `"X"`.
 
 Regarding the anthropogenic soil type polygons, from earlier evaluation it appeared that the _narrow ones that contain 'obliggwdep' types_ are interesting as a whole.
 Hence we select them as a whole instead of selecting buffers around the habitatmap polygons with 'obliggwdep' types.
@@ -35,11 +36,12 @@ Hence we select them as a whole instead of selecting buffers around the habitatm
 - Hence an additional condition was required: a minimal amount of 'obliggwdep' type must be present in such polygons.
 
 Finally, we stitch the parts.
-The resulting new version of `shallowgroundwater` is written here as **`sg2_extended_2.gpkg`**.
+The resulting new version of `shallowgroundwater` is written here as **`sg2_extended_3.gpkg`**.
 
-Hence we will have two separate sources, which we will document as two extra TRUE/FALSE column inside `sg2_extended_2.gpkg`:
+Hence we will have three separate sources, which we will document as three extra TRUE/FALSE column inside `sg2_extended_3.gpkg`:
 
 - `within_soilanthrop_plus_buffer`
+- `within_soildunes_plus_buffer`
 - `narrow_soilanthrop_plus_buffer`
 
 Where an area overlapped between several of these sources, more than one column is set as `TRUE`.
@@ -163,6 +165,16 @@ st_agr(hmt_pol_obliggwdep) <- "constant"
 Creating a geospatial object of anthropogenic soil type polygons, and calculate a property 'thinness' (from [here](https://tereshenkov.wordpress.com/2014/04/08/fighting-sliver-polygons-in-arcgis-thinness-ratio/)) -- lower means more narrow -- as well as the areal fraction occupied by `habitatmap_terr` polygons having 'obliggwdep' types.
 
 ```{r}
+calculate_obliggwdep_occupation <- function(x) {
+  st_intersection(x, hmt_pol_obliggwdep) %>% 
+  mutate(subarea = st_area(.)) %>% 
+  st_drop_geometry %>% 
+  group_by(bsm_poly_id) %>% 
+  summarise(obliggwdep_pol_frac = drop_units(sum(subarea) / first(area)))
+}
+```
+
+```{r}
 soil_anthrop <- 
   soilmap %>% 
   filter(str_sub(bsm_mo_soilunitype, 1, 1) == "O") %>% 
@@ -174,11 +186,7 @@ soil_anthrop <-
 st_agr(soil_anthrop) <- "constant"
 soil_anthrop_occupied <- 
   soil_anthrop %>% 
-  st_intersection(hmt_pol_obliggwdep) %>% 
-  mutate(subarea = st_area(.)) %>% 
-  st_drop_geometry %>% 
-  group_by(bsm_poly_id) %>% 
-  summarise(obliggwdep_pol_frac = drop_units(sum(subarea) / first(area)))
+  calculate_obliggwdep_occupation
 soil_anthrop <- 
   soil_anthrop %>% 
   left_join(soil_anthrop_occupied,
@@ -193,6 +201,34 @@ soil_anthrop %>%
   ggplot(aes(x = thinness)) + 
   geom_histogram(binwidth = 0.01, fill = "white", colour = "grey70")
 soil_anthrop %>% 
+  st_drop_geometry %>% 
+  ggplot(aes(x = obliggwdep_pol_frac)) + 
+  geom_histogram(binwidth = 0.01, fill = "white", colour = "grey70")
+```
+
+Creating a geospatial object of dune texture polygons, with the areal fraction occupied by `habitatmap_terr` polygons having 'obliggwdep' types:
+
+```{r}
+soil_dunes <- 
+  soilmap %>% 
+  filter(bsm_mo_tex == "X") %>% 
+  select(bsm_poly_id, bsm_mo_soilunitype) %>% 
+  mutate(area = st_area(.)) %>% 
+  st_make_valid()
+st_agr(soil_dunes) <- "constant"
+soil_dunes_occupied <- 
+  soil_dunes %>% 
+  calculate_obliggwdep_occupation
+soil_dunes <- 
+  soil_dunes %>% 
+  left_join(soil_dunes_occupied,
+            by = "bsm_poly_id")
+```
+
+The distribution of that areal fraction:
+
+```{r warning=FALSE, out.width='70%'}
+soil_dunes %>% 
   st_drop_geometry %>% 
   ggplot(aes(x = obliggwdep_pol_frac)) + 
   geom_histogram(binwidth = 0.01, fill = "white", colour = "grey70")
@@ -252,6 +288,38 @@ buffered_obliggwdep_within_soilanthrop <-
 
 Resulting object: `buffered_obliggwdep_within_soilanthrop`.
 
+### Buffer `r params$buffer_obliggwdep` m around obliggwdep types, within `soil_dunes`
+
+We create this geospatial object and also write it as a GPKG file, since the calculation takes several minutes.
+
+```{r include=FALSE}
+gpkg_exists <- 
+  file.exists(file.path(datapath, 
+                        "buffered_obliggwdep_within_soildunes.gpkg"))
+```
+
+```{r eval=!gpkg_exists || params$rewrite_intermediate_files}
+# following step takes several minutes!
+buffered_obliggwdep_within_soildunes <-
+  hmt_pol_obliggwdep[soil_dunes, ] %>% 
+  st_make_valid(.) %>% 
+  st_buffer(params$buffer_obliggwdep) %>% 
+  st_union() %>% 
+  st_intersection(soil_dunes)
+write_sf(buffered_obliggwdep_within_soildunes, 
+         file.path(datapath, 
+                   "buffered_obliggwdep_within_soildunes.gpkg"),
+         delete_dsn = TRUE)
+```
+
+```{r eval=gpkg_exists && !params$rewrite_intermediate_files, include = FALSE}
+buffered_obliggwdep_within_soildunes <- 
+  read_sf(file.path(datapath, 
+                    "buffered_obliggwdep_within_soildunes.gpkg"))
+```
+
+Resulting object: `buffered_obliggwdep_within_soildunes`.
+
 ### Narrow anthropogenic soil polygons with 'obliggwdep' types
 
 After several iterations, the below used conditions on `thinness` and `obliggwdep_pol_frac` appeared satisfying.
@@ -294,6 +362,12 @@ buffered_obliggwdep_within_soilanthrop_buff <-
   st_union %>% 
   st_as_sf
 
+buffered_obliggwdep_within_soildunes_buff <- 
+  buffered_obliggwdep_within_soildunes %>% 
+  st_buffer(params$buffer_areas) %>% 
+  st_union %>% 
+  st_as_sf
+
 narrow_soilanthrop_with_obliggwdep_buff <-
   narrow_soilanthrop_with_obliggwdep %>% 
   select(-everything()) %>% 
@@ -305,6 +379,8 @@ if (gpkg_newareas_exists) unlink(file.path(datapath, "new_areas.gpkg"))
 
 list(buffered_obliggwdep_within_soilanthrop_buff =
        buffered_obliggwdep_within_soilanthrop_buff,
+     buffered_obliggwdep_within_soildunes_buff =
+       buffered_obliggwdep_within_soildunes_buff,
      narrow_soilanthrop_with_obliggwdep_buff =
        narrow_soilanthrop_with_obliggwdep_buff) %>% 
   walk2(names(.),
@@ -323,7 +399,7 @@ walk(1:3, function(i) {
 })
 ```
 
-We write the two resulting layers into `new_areas.gpkg`:
+We write the resulting layers into `new_areas.gpkg`:
 
 ```{r paged.print=FALSE}
 st_layers(file.path(datapath, "new_areas.gpkg"))
@@ -338,7 +414,7 @@ The unioning is done in order to prevent overlapping polygons within the same la
 We extend `shallowgroundwater` as described in section \@ref(method).
 
 ```{r include=FALSE}
-gpkg_sg_extended_exists <- file.exists(file.path(datapath, "sg2_extended_2.gpkg"))
+gpkg_sg_extended_exists <- file.exists(file.path(datapath, "sg2_extended_3.gpkg"))
 ```
 
 ```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists, warning=FALSE}
@@ -365,6 +441,21 @@ f <- future({
   elapsed <- 
     system.time(
       result <- qgis_run_algorithm("native:union",
+                                   INPUT = res_filepath,
+                                   OVERLAY = 
+                                     buffered_obliggwdep_within_soildunes_buff %>% 
+                                     mutate(within_soildunes_plus_buffer = TRUE))
+    )
+  list(result = result, elapsed = elapsed)
+}, seed = NULL)
+# resolved(f)
+value(f, stdout = FALSE, signal = FALSE)$elapsed
+res_filepath <- value(f, stdout = FALSE)$result$OUTPUT %>% as.character
+
+f <- future({
+  elapsed <- 
+    system.time(
+      result <- qgis_run_algorithm("native:union",
                                    INPUT = 
                                      sg_repairedgeom,
                                    OVERLAY = 
@@ -378,7 +469,7 @@ value(f, stdout = FALSE, signal = FALSE)$elapsed
 res_filepath2 <- value(f, stdout = FALSE)$result$OUTPUT %>% as.character
 ```
 
-The result is written as `sg2_extended_2.gpkg`.
+The result is written as `sg2_extended_3.gpkg`.
 
 ```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists}
 sg_extended <- 
@@ -390,7 +481,7 @@ sg_extended <-
 ```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists}
 system.time(
 st_write(sg_extended,
-         file.path(datapath, "sg2_extended_2.gpkg"),
+         file.path(datapath, "sg2_extended_3.gpkg"),
          layer = "sg_extended",
          delete_dsn = TRUE,
          quiet = TRUE)

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -185,7 +185,9 @@ soil_anthrop %>%
 
 # Execution
 
-## Buffer 500 m around obliggwdep types, within `soil_anthrop`
+## Zones where shallow groundwater is more probable
+
+### Buffer 500 m around obliggwdep types, within `soil_anthrop`
 
 We create this geospatial object and also write it as a GPKG file, since the calculation takes several minutes.
 
@@ -217,7 +219,7 @@ buffered_obliggwdep_within_soilanthrop <-
 
 Resulting object: `buffered_obliggwdep_within_soilanthrop`.
 
-## Narrow anthropogenic soil polygons with 'obliggwdep' types, buffered by 100 m
+### Narrow anthropogenic soil polygons with 'obliggwdep' types
 
 After several iterations, the below used conditions on `thinness` and `obliggwdep_pol_frac` appeared satisfying.
 
@@ -239,7 +241,7 @@ mapview(narrow_soilanthrop_with_obliggwdep,
 
 Resulting object: `narrow_soilanthrop_with_obliggwdep`.
 
-## Buffer 500 m around obliggwdep types, that are within 200 m of `shallowgroundwater`
+### Buffer 500 m around obliggwdep types, that are within 200 m of `shallowgroundwater`
 
 
 ```{r eval=!gpkg_sg_exists}
@@ -376,7 +378,7 @@ buffered_obliggwdep_within_sg_ring <-
 Resulting object: `buffered_obliggwdep_within_sg_ring`.
 
 
-## Buffer 200 m around `buffered_obliggwdep_within_soilanthrop`, `narrow_soilanthrop_with_obliggwdep` and `buffered_obliggwdep_within_sg_ring`
+## Add 200 m buffer around previously created zones to minimize false negatives
 
 ```{r include=FALSE}
 gpkg_newareas_exists <- 
@@ -419,3 +421,10 @@ walk(1:3, function(i) {
                  layer = layername))
 })
 ```
+
+## Intersect the new zones, subtract the original `shallowgroundwater` layer and append
+
+
+
+
+

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -67,8 +67,8 @@ sgpath <- find_root_file("n2khab_data/10_raw/shallowgroundwater",
 if (!dir.exists(sgpath) | list.files(sgpath) %>% length == 0) {
   dir.create(sgpath)
   drive_auth(email = TRUE)
-  # downloads "ZonesOndiepGrondwater_20211004.gpkg":
-  as_id("12EEomOBcKg0NMUPwsFDyKhqJSvrS8xs8") %>% 
+  # downloads "ZonesOndiepGrondwater_20211129.gpkg":
+  as_id("18ZHt8hoeuWNYzFadwR54g5-rLsW2CYmb") %>% 
     drive_download(file.path(sgpath, "shallowgroundwater.gpkg"), 
                    overwrite = TRUE)
 }
@@ -88,7 +88,7 @@ checksums %>%
 
 ```{r}
 if (any(checksums != 
-        c(shallowgroundwater.gpkg = "68646fe7362d8bf6"))
+        c(shallowgroundwater.gpkg = "0052a67f88296b60"))
 ) stop("Beware, your version of shallowgroundwater is not the one for which this code was intended!")
 ```
 
@@ -120,7 +120,9 @@ gpkg_sg_union_exists <-
 ```
 
 ```{r eval=!gpkg_sg_exists || params$consider_sg_as_new}
-sg <- read_sf(file.path(sgpath, "shallowgroundwater.gpkg"), crs = 31370)
+sg <- read_sf(file.path(sgpath, "shallowgroundwater.gpkg"), 
+              layer = params$input_layername,
+              crs = 31370)
 ```
 
 ```{r eval=FALSE, echo=FALSE}

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -64,14 +64,19 @@ if (!dir.exists(datapath)) dir.create(datapath)
 sgpath <- find_root_file("n2khab_data/10_raw/shallowgroundwater", 
                             criterion = has_dir("n2khab_data"))
 
-if (!dir.exists(sgpath) | list.files(sgpath) %>% length == 0) {
-  dir.create(sgpath)
-  drive_auth(email = TRUE)
-  # downloads "ZonesOndiepGrondwater_20211129.gpkg":
-  as_id("18ZHt8hoeuWNYzFadwR54g5-rLsW2CYmb") %>% 
-    drive_download(file.path(sgpath, "shallowgroundwater.gpkg"), 
-                   overwrite = TRUE)
-}
+if (!dir.exists(sgpath)) dir.create(sgpath)
+inputpath <- file.path(tempdir(), "shallowgroundwater")
+dir.create(inputpath, showWarnings = FALSE)
+
+drive_auth(email = TRUE)
+# download "shallowgroundwater_20211129.gpkg.zip", which only contains the 
+# "ZOG_20211129_diss" layer from ZonesOndiepGrondwater_20211129.gpkg":
+as_id("1bCQUMm1s0iDwr6HWe12bWQpBRiY-YS3H") %>% 
+  drive_download(file.path(inputpath, "shallowgroundwater.gpkg.zip"), 
+                 overwrite = TRUE)
+unzip(file.path(inputpath, "shallowgroundwater.gpkg.zip"),
+      exdir = inputpath)
+unlink(file.path(inputpath, "shallowgroundwater.gpkg.zip"))
 ```
 
 Verification of several input data sets.
@@ -80,20 +85,18 @@ Checksums of `shallowgroundwater` (using default algorithm of `n2khab::checksum(
 
 ```{r}
 checksums <- 
-  list.files(sgpath, full.names = TRUE) %>% 
+  list.files(inputpath, full.names = TRUE) %>% 
   checksum
 checksums %>% 
   as.matrix
 ```
 
 ```{r}
-if (!file.exists(file.path(sgpath, "shallowgroundwater.gpkg"))) {
-  stop("It seems that you have manually put a file inside ",
-       sgpath,
-       "\nMake sure that you name this file as shallowgroundwater.gpkg !")
+if (!file.exists(file.path(inputpath, "shallowgroundwater.gpkg"))) {
+  stop("The input GeoPackage file is missing from ", inputpath)
 }
 if (any(checksums != 
-        c(shallowgroundwater.gpkg = "0052a67f88296b60"))
+        c(shallowgroundwater.gpkg = "29660a8672412c95"))
 ) stop("Beware, your version of shallowgroundwater is not the one for which this code was intended!")
 ```
 
@@ -125,7 +128,7 @@ gpkg_sg_union_exists <-
 ```
 
 ```{r eval=!gpkg_sg_exists || params$consider_sg_as_new}
-sg <- read_sf(file.path(sgpath, "shallowgroundwater.gpkg"), 
+sg <- read_sf(file.path(inputpath, "shallowgroundwater.gpkg"), 
               layer = params$input_layername,
               crs = 31370)
 ```
@@ -432,7 +435,7 @@ The unioning is done in order to get the simplest possible intersection result i
 We extend `shallowgroundwater` as described in section \@ref(method).
 
 ```{r include=FALSE}
-gpkg_sg_extended_exists <- file.exists(file.path(datapath, output_filename))
+gpkg_sg_extended_exists <- file.exists(file.path(sgpath, output_filename))
 ```
 
 ```{r intersecting, eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists, warning=FALSE}
@@ -508,8 +511,8 @@ sg_extended <-
 ```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists}
 system.time(
 st_write(sg_extended,
-         file.path(datapath, output_filename),
-         layer = "sg_extended",
+         file.path(sgpath, output_filename),
+         layer = "shallowgroundwater",
          delete_dsn = TRUE,
          quiet = TRUE)
 )

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -43,9 +43,9 @@ The resulting new version of `shallowgroundwater` is written here as **``r outpu
 
 Hence we will have three separate sources, which we will document as three extra TRUE/FALSE column inside ``r output_filename``:
 
-- `within_soilanthrop`
-- `within_soildunes`
-- `narrow_soilanthrop`
+- `anthrop_gwdep`
+- `narrowanthrop_gwdep`
+- `dunes_gwdep`
 
 Where an area overlapped between several of these sources, more than one column is set as `TRUE`.
 
@@ -447,10 +447,10 @@ f <- future({
       result <- qgis_run_algorithm("native:union",
                                    INPUT = 
                                      buffered_obliggwdep_within_soilanthrop %>% 
-                                     mutate(within_soilanthrop = TRUE),
+                                     mutate(anthrop_gwdep = TRUE),
                                    OVERLAY = 
                                      narrow_soilanthrop_with_obliggwdep %>% 
-                                     mutate(narrow_soilanthrop = TRUE))
+                                     mutate(narrowanthrop_gwdep = TRUE))
     )
   list(result = result, elapsed = elapsed)
 }, seed = NULL)
@@ -465,7 +465,7 @@ f <- future({
                                    INPUT = res_filepath,
                                    OVERLAY = 
                                      buffered_obliggwdep_within_soildunes %>% 
-                                     mutate(within_soildunes = TRUE))
+                                     mutate(dunes_gwdep = TRUE))
     )
   list(result = result, elapsed = elapsed)
 }, seed = NULL)

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -114,7 +114,7 @@ gpkg_sg_union_exists <-
                         "sg_repairedgeom_union.gpkg"))
 ```
 
-```{r eval=!gpkg_sg_exists}
+```{r eval=!gpkg_sg_exists || params$consider_sg_as_new}
 sg <- read_sf(file.path(sgpath, "shallowgroundwater.gpkg"), crs = 31370)
 ```
 
@@ -237,7 +237,7 @@ soil_dunes %>%
 
 Cleaning `shallowgroundwater` geometry.
 
-```{r eval=!gpkg_sg_exists}
+```{r eval=!gpkg_sg_exists || params$consider_sg_as_new}
 sg_repairedgeom <- 
   st_make_valid(sg) %>% 
   st_cast("MULTIPOLYGON")
@@ -247,14 +247,14 @@ write_sf(sg_repairedgeom,
          delete_dsn = TRUE)
 ```
 
-```{r eval=gpkg_sg_exists, include=FALSE}
+```{r eval=gpkg_sg_exists && !params$consider_sg_as_new, include=FALSE}
 sg_repairedgeom <- 
   read_sf(file.path(datapath, 
                     "sg_repairedgeom.gpkg"))
 ```
 
 
-```{r eval=!gpkg_sg_union_exists && params$union_sg}
+```{r eval=(!gpkg_sg_union_exists || params$consider_sg_as_new) && params$union_sg}
 sg_repairedgeom_union <- 
   sg_repairedgeom %>% 
   st_union %>% 
@@ -265,7 +265,7 @@ write_sf(sg_repairedgeom_union,
          delete_dsn = TRUE)
 ```
 
-```{r eval=gpkg_sg_union_exists && params$union_sg, include=FALSE}
+```{r eval=gpkg_sg_union_exists && params$union_sg && !params$consider_sg_as_new, include=FALSE}
 sg_repairedgeom_union <- 
   read_sf(file.path(datapath, 
                     "sg_repairedgeom_union.gpkg"))

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -364,11 +364,6 @@ write_sf(buffered_obliggwdep_within_sg_ring,
 ```
 
 
-```{r}
-plan(sequential)
-```
-
-
 ```{r eval=gpkg_buffered_obliggwdep_within_sg_ring_exists, include=FALSE}
 buffered_obliggwdep_within_sg_ring <- 
   read_sf(file.path(datapath, 
@@ -505,5 +500,9 @@ write_sf(sg_extended,
          delete_dsn = TRUE,
          )
 )
+```
+
+```{r}
+plan(sequential)
 ```
 

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -81,8 +81,7 @@ if (checksum(sspath) != "9f4204b476506031") stop("Incorrect soilmap_simple versi
 hmtpath <- find_root_file("n2khab_data/20_processed/habitatmap_terr/habitatmap_terr.gpkg", 
                             criterion = has_dir("n2khab_data"))
 if (!file.exists(hmtpath)) stop("Please organize habitatmap_terr location. See https://inbo.github.io/n2khab")
-assertthat::assert_that(checksum(hmtpath) == "72d3144016e816ed",
-                        msg = "Incorrect habitatmap_terr version.")
+if (checksum(hmtpath) != "72d3144016e816ed") stop("Incorrect habitatmap_terr version.")
 ```
 
 Reading data sets.

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -427,7 +427,7 @@ gpkg_sg_extended_exists <- file.exists(file.path(datapath, "sg_extended.gpkg"))
 ```
 
 
-```{r eval=params$overwrite_sg_extended | !gpkg_sg_extended_exists}
+```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists}
 # use of future unneeded in this case (runs quickly)
 f <- future({
   elapsed <- 
@@ -463,7 +463,7 @@ value(f, stdout = FALSE, signal = FALSE)$elapsed
 res_filepath2 <- value(f, stdout = FALSE)$result$OUTPUT %>% as.character
 ```
 
-```{r eval=params$overwrite_sg_extended | !gpkg_sg_extended_exists}
+```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists}
 f <- future({
   elapsed <- 
     system.time(
@@ -483,7 +483,7 @@ value(f, stdout = FALSE, signal = FALSE)$elapsed
 addition <- value(f, stdout = FALSE)$result
 ```
 
-```{r eval=params$overwrite_sg_extended | !gpkg_sg_extended_exists}
+```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists}
 sg_extended <- 
   sg_repairedgeom %>% 
   as_tibble %>% 
@@ -493,7 +493,7 @@ sg_extended <-
   st_sf(crs = 31370)
 ```
 
-```{r eval=params$overwrite_sg_extended | !gpkg_sg_extended_exists}
+```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists}
 system.time(
 write_sf(sg_extended,
          file.path(datapath, "sg_extended.gpkg"),

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -487,7 +487,10 @@ f <- future({
         } else {
           qgis_run_algorithm("native:union",
                              INPUT = 
-                               sg_repairedgeom,
+                               sg_repairedgeom %>% 
+                               select(-OBJECTID, 
+                                      -Shape_Length,
+                                      -Shape_Area),
                              OVERLAY = 
                                res_filepath)
         }

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -454,7 +454,8 @@ walk(1:3, function(i) {
   layername <- st_layers(file.path(datapath, "new_areas.gpkg"))$name[i]
   assign(layername,
          read_sf(file.path(datapath, "new_areas.gpkg"),
-                 layer = layername))
+                 layer = layername),
+         envir = parent.env(environment()))
 })
 ```
 

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -436,6 +436,8 @@ buffered_obliggwdep_within_sg_ring_buff200 <-
   st_buffer(200) %>% 
   st_as_sf
 
+if (gpkg_newareas_exists) unlink(file.path(datapath, "new_areas.gpkg"))
+
 list(buffered_obliggwdep_within_soilanthrop_buff200 =
        buffered_obliggwdep_within_soilanthrop_buff200,
      narrow_soilanthrop_with_obliggwdep_buff200 =

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -197,7 +197,7 @@ gpkg_exists <-
                         "buffered_obliggwdep_within_soilanthrop.gpkg"))
 ```
 
-```{r eval=!gpkg_exists}
+```{r eval=!gpkg_exists || params$rewrite_intermediate_files}
 # following step takes several minutes!
 buffered_obliggwdep_within_soilanthrop <-
   hmt_pol_obliggwdep[soil_anthrop, ] %>% 
@@ -211,7 +211,7 @@ write_sf(buffered_obliggwdep_within_soilanthrop,
          delete_dsn = TRUE)
 ```
 
-```{r eval=gpkg_exists, include = FALSE}
+```{r eval=gpkg_exists && !params$rewrite_intermediate_files, include = FALSE}
 buffered_obliggwdep_within_soilanthrop <- 
   read_sf(file.path(datapath, 
                     "buffered_obliggwdep_within_soilanthrop.gpkg"))
@@ -266,7 +266,7 @@ gpkg_sg_ring_exists <-
                         "sg_ring.gpkg"))
 ```
 
-```{r eval=!gpkg_sg_ring_exists}
+```{r eval=!gpkg_sg_ring_exists || params$rewrite_intermediate_files}
 system.time({
 sg_union <-
   sg_repairedgeom %>%
@@ -285,7 +285,7 @@ write_sf(sg_ring,
          delete_dsn = TRUE)
 ```
 
-```{r eval=gpkg_sg_ring_exists, include=FALSE}
+```{r eval=gpkg_sg_ring_exists && !params$rewrite_intermediate_files, include=FALSE}
 sg_ring <- 
   read_sf(file.path(datapath, 
                     "sg_ring.gpkg"))
@@ -308,7 +308,7 @@ gpkg_buffered_obliggwdep_within_sg_ring_exists <-
                         "buffered_obliggwdep_within_sg_ring.gpkg"))
 ```
 
-```{r eval=!gpkg_buffered_obliggwdep_within_sg_ring_exists}
+```{r eval=!gpkg_buffered_obliggwdep_within_sg_ring_exists || params$rewrite_intermediate_files}
 # qgis_algorithms() %>% filter(str_detect(algorithm, "extract"))
 # qgis_show_help("native:extractbylocation")
 hmt_pol_obliggwdep %>% 
@@ -319,12 +319,12 @@ hmt_pol_obliggwdep %>%
 ```
 
 
-```{r eval=!gpkg_buffered_obliggwdep_within_sg_ring_exists}
+```{r eval=!gpkg_buffered_obliggwdep_within_sg_ring_exists || params$rewrite_intermediate_files}
 plan(multisession) # future kept here as demonstration
 ```
 
 
-```{r eval=!gpkg_buffered_obliggwdep_within_sg_ring_exists}
+```{r eval=!gpkg_buffered_obliggwdep_within_sg_ring_exists || params$rewrite_intermediate_files}
 # use of future unneeded in this case (runs quickly; however
 # hmt_pol_obliggwdep[sg_ring, ] takes very long)
 f <- future({
@@ -340,7 +340,7 @@ obliggwdep_sgring_qgis <- value(f, stdout = FALSE) # blocks calling R session if
 ```
 
 
-```{r eval=!gpkg_buffered_obliggwdep_within_sg_ring_exists}
+```{r eval=!gpkg_buffered_obliggwdep_within_sg_ring_exists || params$rewrite_intermediate_files}
 # use of future unneeded in this case (runs quickly)
 f <- future({
   elapsed <- 
@@ -364,7 +364,7 @@ write_sf(buffered_obliggwdep_within_sg_ring,
 ```
 
 
-```{r eval=gpkg_buffered_obliggwdep_within_sg_ring_exists, include=FALSE}
+```{r eval=gpkg_buffered_obliggwdep_within_sg_ring_exists && !params$rewrite_intermediate_files, include=FALSE}
 buffered_obliggwdep_within_sg_ring <- 
   read_sf(file.path(datapath, 
                     "buffered_obliggwdep_within_sg_ring.gpkg"))
@@ -381,7 +381,7 @@ gpkg_newareas_exists <-
                         "new_areas.gpkg"))
 ```
 
-```{r eval=!gpkg_newareas_exists}
+```{r eval=!gpkg_newareas_exists || params$rewrite_intermediate_files}
 buffered_obliggwdep_within_soilanthrop_buff200 <- 
   buffered_obliggwdep_within_soilanthrop %>% 
   st_buffer(200) %>% 
@@ -411,7 +411,7 @@ list(buffered_obliggwdep_within_soilanthrop_buff200 =
                   layer = .y))
 ```
 
-```{r eval=gpkg_newareas_exists, include=FALSE}
+```{r eval=gpkg_newareas_exists && !params$rewrite_intermediate_files, include=FALSE}
 walk(1:3, function(i) {
   layername <- st_layers(file.path(datapath, "new_areas.gpkg"))$name[i]
   assign(layername,

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -16,7 +16,7 @@ Hence, the area it covers needs to be made broader.
 
 In this document, we generate several sets of _extra polygons_ to be added to shallowgroundwater:
 
-- _within_ anthropogenic soil types (using the `bsm_mo_soilunitype` column of the `soilmap_simple` data source): buffers of 500 m around the '(almost) everywhere groundwater dependent' types (here also called 'obliggwdep' types);
+- _within_ anthropogenic soil types (using the `bsm_mo_soilunitype` column of the `soilmap_simple` data source): buffers of `r params$buffer_obliggwdep` m around the '(almost) everywhere groundwater dependent' types (here also called 'obliggwdep' types);
 - for narrow anthropogenic soil type polygons: if they contain 'obliggwdep' types, then add them as a whole.
 An appropriate algorithm has to be made that selects meaningful polygons - often it appears that complete cities would meet the foregoing requirement, so a sufficient amount of 'obliggwdep' type will need to be present in such polygons;
 - buffering `shallowgroundwater`
@@ -187,7 +187,7 @@ soil_anthrop %>%
 
 ## Zones where shallow groundwater is more probable
 
-### Buffer 500 m around obliggwdep types, within `soil_anthrop`
+### Buffer `r params$buffer_obliggwdep` m around obliggwdep types, within `soil_anthrop`
 
 We create this geospatial object and also write it as a GPKG file, since the calculation takes several minutes.
 
@@ -202,7 +202,7 @@ gpkg_exists <-
 buffered_obliggwdep_within_soilanthrop <-
   hmt_pol_obliggwdep[soil_anthrop, ] %>% 
   st_make_valid(.) %>% 
-  st_buffer(500) %>% 
+  st_buffer(params$buffer_obliggwdep) %>% 
   st_union() %>% 
   st_intersection(soil_anthrop)
 write_sf(buffered_obliggwdep_within_soilanthrop, 
@@ -241,7 +241,7 @@ mapview(narrow_soilanthrop_with_obliggwdep,
 
 Resulting object: `narrow_soilanthrop_with_obliggwdep`.
 
-### Buffer 500 m around obliggwdep types, that are within 200 m of `shallowgroundwater`
+### Buffer `r params$buffer_obliggwdep` m around obliggwdep types, that are within 200 m of `shallowgroundwater`
 
 
 ```{r eval=!gpkg_sg_exists}
@@ -297,7 +297,7 @@ system.time(
 buffered_obliggwdep_nearsg <-
   hmt_pol_obliggwdep[sg_ring, ] %>% # especially this takes an age. Will use QGIS here.
   st_make_valid(.) %>% 
-  st_buffer(500) %>% 
+  st_buffer(params$buffer_obliggwdep) %>% 
   st_union()
 )
 ```
@@ -348,7 +348,7 @@ f <- future({
       result <-
         obliggwdep_sgring_qgis$OUTPUT %>% 
         read_sf %>% 
-        st_buffer(500) %>% 
+        st_buffer(params$buffer_obliggwdep) %>% 
         st_union() %>% 
         st_intersection(sg_ring)
     )

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -9,17 +9,46 @@ It is more specifically applied to restrict the 'locally groundwater dependent' 
 - Data and metadata are in [a GDrive folder](https://drive.google.com/drive/u/0/folders/1S9colwuaMNmB58u4RUnB0MqZLyIUZ9rT).
 - More info about checking the data source: see <https://github.com/inbo/n2khab-mne-design/pull/74> and links therein.
 
-Based on an evaluation that uses the '(almost) everywhere groundwater dependent' types, the current state does not yet cover a significant proportion of those types.
+Based on an evaluation that uses the '(almost) everywhere groundwater dependent' types, the current state still mismatches a significant proportion of those types.
 Hence, the area it covers needs to be made broader.
 
-## Aim
+## Aim and method {#method}
 
-In this document, we generate several sets of _extra polygons_ to be added to shallowgroundwater:
+In this document, we append several layers to `shallowgroundwater`.
+The **aim** is to select areas which `shallowgroundwater` doesn't cover yet and where '(almost) everywhere groundwater dependent' types (here also called 'obliggwdep' types) are present.
+Such 'areas of interest' are e.g. anthropogenic soil type polygons, and a ring around the borders of `shallowgroundwater`.
 
-- _within_ anthropogenic soil types (using the `bsm_mo_soilunitype` column of the `soilmap_simple` data source): buffers of `r params$buffer_obliggwdep` m around the '(almost) everywhere groundwater dependent' types (here also called 'obliggwdep' types);
-- for narrow anthropogenic soil type polygons: if they contain 'obliggwdep' types, then add them as a whole.
-An appropriate algorithm has to be made that selects meaningful polygons - often it appears that complete cities would meet the foregoing requirement, so a sufficient amount of 'obliggwdep' type will need to be present in such polygons;
-- buffering `shallowgroundwater`
+- In order not to exaggerate the extension of `shallowgroundwater`, we will subseqently limit those areas to _buffers (of `r params$buffer_obliggwdep` m) around habitatmap polygons with 'obliggwdep' types_ -- still clipping along the borders of the aforementioned areas.
+So in practice, we first select the habitatmap polygons with 'obliggwdep' types that intersect the areas of interest, we buffer them, and we clip the result along the areas of interest.
+  - The buffers around habitatmap polygons with 'obliggwdep' types are applied since it is expected that shallow groundwater (with potentially 'locally groundwater dependent' types) will occur in their vicinity.
+- In a next step, we want to add a _buffer of 200 m_ around the resulting polygons.
+This is done as a further means of conservative area selection: we rather need too much area than too little, given the ultimate aim of restricting target populations.
+
+The areas of interest are:
+
+- all _anthropogenic soil type polygons_: i.e. where the `bsm_mo_soilunitype` column of the `soilmap_simple` data source starts with `O`;
+- a _ring around_ `shallowgroundwater` of 200 m wide.
+
+Regarding the anthropogenic soil type polygons, from earlier evaluation it appeared that the _narrow ones that contain 'obliggwdep' types_ are interesting as a whole.
+Hence we select them as a whole instead of selecting buffers around the habitatmap polygons with 'obliggwdep' types (before finally adding the buffer of 200 m to these soil type polygons):
+
+- An appropriate algorithm had to be made that selects meaningful polygons - at first it resulted in complete cities meeting the narrowness requirement (since they are part of polygons with long, narrow parts).
+- Hence an additional condition was required: a sufficient amount of 'obliggwdep' type must be present in such polygons.
+
+Finally, we append the parts -- of all new layers -- that don't overlap `shallowgroundwater`, to `shallowgroundwater`.
+The resulting new version of `shallowgroundwater` is written here as **`sg_extended.gpkg`**.
+
+Hence we will have three separate sources, which we will document as three extra TRUE/FALSE column inside `sg_extended.gpkg`:
+
+- `within_soilanthrop_plus_buffer`
+- `narrow_soilanthrop_plus_buffer`
+- `nearby_originalsg_plus_buffer`
+
+Where an area overlapped between several of these sources, more than one column is set as `TRUE`.
+
+We do most geoprocessing tasks using `sf` (mostly using GEOS as backend).
+However in some cases we use `qgisprocess` (QGIS as backend) when the QGIS algorithm is either faster than or absent from `sf`.
+
 
 # Preparation
 
@@ -50,6 +79,8 @@ if (!dir.exists(sgpath) | list.files(sgpath) %>% length == 0) {
 ```
 
 Verification of several input data sets.
+
+Checksums (using default algorithm of `n2khab::checksum()`) of `shallowgroundwater`:
 
 ```{r}
 checksums <- 
@@ -101,6 +132,7 @@ sg <- read_sf(sgpath, crs = 31370)
 ```
 
 ```{r eval=FALSE, echo=FALSE}
+# Preparatory exploration of anthropogenic areas:
 read_soilmap(use_processed = FALSE) %>% 
   st_drop_geometry %>% 
   filter(str_sub(bsm_mo_soilunitype, 1, 1) == "O") %>% 
@@ -144,7 +176,7 @@ hmt_pol_obliggwdep <-
 st_agr(hmt_pol_obliggwdep) <- "constant"
 ```
 
-Creating a geospatial object of anthropogenic soil type polygons, and calculate a property 'thinness' (from [here](https://tereshenkov.wordpress.com/2014/04/08/fighting-sliver-polygons-in-arcgis-thinness-ratio/)) - lower means more narrow - as well as the areal fraction occupied by `habitatmap_terr` polygons having 'obliggwdep' types.
+Creating a geospatial object of anthropogenic soil type polygons, and calculate a property 'thinness' (from [here](https://tereshenkov.wordpress.com/2014/04/08/fighting-sliver-polygons-in-arcgis-thinness-ratio/)) -- lower means more narrow -- as well as the areal fraction occupied by `habitatmap_terr` polygons having 'obliggwdep' types.
 
 ```{r}
 soil_anthrop <- 
@@ -184,7 +216,7 @@ soil_anthrop %>%
 
 # Execution
 
-## Zones where shallow groundwater is more probable
+## Generating the areas of interest (where shallow groundwater is more probable)
 
 ### Buffer `r params$buffer_obliggwdep` m around obliggwdep types, within `soil_anthrop`
 
@@ -230,6 +262,7 @@ narrow_soilanthrop_with_obliggwdep <-
   st_cast("MULTIPOLYGON")
 ```
 
+Interactive map:
 
 ```{r out.width='800px', out.height='500px'}
 mapview(narrow_soilanthrop_with_obliggwdep,
@@ -242,6 +275,7 @@ Resulting object: `narrow_soilanthrop_with_obliggwdep`.
 
 ### Buffer `r params$buffer_obliggwdep` m around obliggwdep types, that are within 200 m of `shallowgroundwater`
 
+We will first create a ring around `shallowgroundwater` of 200 m width.
 
 ```{r eval=!gpkg_sg_exists}
 sg_repairedgeom <- 
@@ -289,6 +323,8 @@ sg_ring <-
   read_sf(file.path(datapath, 
                     "sg_ring.gpkg"))
 ```
+
+Then we create the buffered habitatmap polygons with 'obliggwdep' types within the ring.
 
 ```{r eval=FALSE, echo=FALSE}
 # following step takes too much time! Interrupted this manually.
@@ -419,7 +455,18 @@ walk(1:3, function(i) {
 })
 ```
 
+We write the three resulting layers into `new_areas.gpkg`:
+
+```{r paged.print=FALSE}
+st_layers(file.path(datapath, "new_areas.gpkg"))
+```
+
+Each layer consists of just one Multipolygon.
+That is the result of unioning steps (`st_union()`; corresponding QGIS terminology is `native:aggregate`) in order to prevent overlapping polygons within the same layer, as a consequence of creating buffers.
+
 ## Union the new zones (keeping intersections), subtract the original `shallowgroundwater` layer and append
+
+We extend `shallowgroundwater` as described in paragraph \@ref(method).
 
 ```{r include=FALSE}
 gpkg_sg_extended_exists <- file.exists(file.path(datapath, "sg_extended.gpkg"))
@@ -482,6 +529,8 @@ f <- future({
 value(f, stdout = FALSE, signal = FALSE)$elapsed
 addition <- value(f, stdout = FALSE)$result
 ```
+
+The result is written as `sg_extended.gpkg`.
 
 ```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists}
 sg_extended <- 

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -111,6 +111,9 @@ soilmap <- read_soilmap()
 gpkg_sg_exists <- 
   file.exists(file.path(datapath, 
                         "sg_repairedgeom.gpkg"))
+gpkg_sg_union_exists <- 
+  file.exists(file.path(datapath, 
+                        "sg_repairedgeom_union.gpkg"))
 ```
 
 ```{r eval=!gpkg_sg_exists}
@@ -250,6 +253,24 @@ write_sf(sg_repairedgeom,
 sg_repairedgeom <- 
   read_sf(file.path(datapath, 
                     "sg_repairedgeom.gpkg"))
+```
+
+
+```{r eval=!gpkg_sg_union_exists && params$union_sg}
+sg_repairedgeom_union <- 
+  sg_repairedgeom %>% 
+  st_union %>% 
+  st_as_sf
+write_sf(sg_repairedgeom_union,
+         file.path(datapath, 
+                   "sg_repairedgeom_union.gpkg"),
+         delete_dsn = TRUE)
+```
+
+```{r eval=gpkg_sg_union_exists && params$union_sg, include=FALSE}
+sg_repairedgeom_union <- 
+  read_sf(file.path(datapath, 
+                    "sg_repairedgeom_union.gpkg"))
 ```
 
 # Execution

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -425,30 +425,85 @@ walk(1:3, function(i) {
 })
 ```
 
-## Intersect the new zones, subtract the original `shallowgroundwater` layer and append
+## Union the new zones (keeping intersections), subtract the original `shallowgroundwater` layer and append
 
-```{r}
+```{r include=FALSE}
+gpkg_sg_extended_exists <- file.exists(file.path(datapath, "sg_extended.gpkg"))
+```
+
+
+```{r eval=params$overwrite_sg_extended | !gpkg_sg_extended_exists}
 # use of future unneeded in this case (runs quickly)
 f <- future({
   elapsed <- 
     system.time(
       result <- qgis_run_algorithm("native:union",
-                                   INPUT = file.path(datapath, 
-                                                     "new_areas.gpkg") %>% 
-                                     str_c("|layername=",
-                                           "buffered_obliggwdep_within_soilanthrop_buff200"),
-                                   OVERLAY = file.path(datapath, 
-                                                     "new_areas.gpkg") %>% 
-                                     str_c("|layername=",
-                                           "narrow_soilanthrop_with_obliggwdep_buff200"))
+                                   INPUT = 
+                                     buffered_obliggwdep_within_soilanthrop_buff200 %>% 
+                                     mutate(within_soilanthrop_plus_buffer = TRUE),
+                                   OVERLAY = 
+                                     narrow_soilanthrop_with_obliggwdep_buff200 %>% 
+                                     mutate(narrow_soilanthrop_plus_buffer = TRUE))
     )
   list(result = result, elapsed = elapsed)
 }, seed = NULL)
 # resolved(f)
 value(f, stdout = FALSE, signal = FALSE)$elapsed
-res <- value(f, stdout = FALSE)$result$OUTPUT
+res_filepath <- value(f, stdout = FALSE)$result$OUTPUT %>% as.character
+
+f <- future({
+  elapsed <- 
+    system.time(
+      result <- qgis_run_algorithm("native:union",
+                                   INPUT = 
+                                     res_filepath,
+                                   OVERLAY = 
+                                     buffered_obliggwdep_within_sg_ring_buff200 %>% 
+                                     mutate(nearby_originalsg_plus_buffer = TRUE))
+    )
+  list(result = result, elapsed = elapsed)
+}, seed = NULL)
+# resolved(f)
+value(f, stdout = FALSE, signal = FALSE)$elapsed
+res_filepath2 <- value(f, stdout = FALSE)$result$OUTPUT %>% as.character
 ```
 
+```{r eval=params$overwrite_sg_extended | !gpkg_sg_extended_exists}
+f <- future({
+  elapsed <- 
+    system.time(
+      result <- 
+        read_sf(res_filepath2) %>% 
+        select(-starts_with("fid")) %>% 
+        mutate(across(where(is.logical), ~ifelse(is.na(.), FALSE, .))) %>% 
+        st_difference(
+          sg_repairedgeom %>% 
+            st_union()
+        )
+    )
+  list(result = result, elapsed = elapsed)
+}, seed = NULL)
+# resolved(f)
+value(f, stdout = FALSE, signal = FALSE)$elapsed
+addition <- value(f, stdout = FALSE)$result
+```
 
+```{r eval=params$overwrite_sg_extended | !gpkg_sg_extended_exists}
+sg_extended <- 
+  sg_repairedgeom %>% 
+  as_tibble %>% 
+  bind_rows(
+    addition %>% as_tibble
+  ) %>% 
+  st_sf(crs = 31370)
+```
 
+```{r eval=params$overwrite_sg_extended | !gpkg_sg_extended_exists}
+system.time(
+write_sf(sg_extended,
+         file.path(datapath, "sg_extended.gpkg"),
+         delete_dsn = TRUE,
+         )
+)
+```
 

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -366,12 +366,10 @@ f <- future({
     system.time(
       result <- qgis_run_algorithm("native:union",
                                    INPUT = 
-                                     res_filepath,
+                                     sg_repairedgeom,
                                    OVERLAY = 
-                                     sg_repairedgeom %>% 
-                                     st_union %>% 
-                                     st_as_sf %>% 
-                                     mutate(sg = TRUE))
+                                     res_filepath
+)
     )
   list(result = result, elapsed = elapsed)
 }, seed = NULL)

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -476,14 +476,21 @@ res_filepath <- value(f, stdout = FALSE)$result$OUTPUT %>% as.character
 f <- future({
   elapsed <- 
     system.time(
-      result <- qgis_run_algorithm("native:union",
-                                   INPUT = 
-                                     res_filepath,
-                                   OVERLAY = 
-                                     sg_repairedgeom %>% 
-                                     st_union %>% 
-                                     st_as_sf %>% 
-                                     mutate(sg = TRUE))
+      result <- 
+        if(params$union_sg) {
+          qgis_run_algorithm("native:union",
+                             INPUT = 
+                               res_filepath,
+                             OVERLAY = 
+                               sg_repairedgeom_union %>% 
+                               mutate(sg = TRUE))
+        } else {
+          qgis_run_algorithm("native:union",
+                             INPUT = 
+                               sg_repairedgeom,
+                             OVERLAY = 
+                               res_filepath)
+        }
     )
   list(result = result, elapsed = elapsed)
 }, seed = NULL)

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -432,7 +432,8 @@ narrow_soilanthrop_with_obliggwdep_buff200 <-
 
 buffered_obliggwdep_within_sg_ring_buff200 <- 
   buffered_obliggwdep_within_sg_ring %>% 
-  st_buffer(200)
+  st_buffer(200) %>% 
+  st_as_sf
 
 list(buffered_obliggwdep_within_soilanthrop_buff200 =
        buffered_obliggwdep_within_soilanthrop_buff200,

--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -67,7 +67,10 @@ sgpath <- find_root_file("n2khab_data/10_raw/shallowgroundwater",
 if (!dir.exists(sgpath)) dir.create(sgpath)
 inputpath <- file.path(tempdir(), "shallowgroundwater")
 dir.create(inputpath, showWarnings = FALSE)
+```
 
+
+```{r}
 drive_auth(email = TRUE)
 # download "shallowgroundwater_20211129.gpkg.zip", which only contains the 
 # "ZOG_20211129_diss" layer from ZonesOndiepGrondwater_20211129.gpkg":

--- a/src/update_shallowgroundwater/20_check_result.Rmd
+++ b/src/update_shallowgroundwater/20_check_result.Rmd
@@ -29,7 +29,7 @@ glimpse(pol)
 - Sensible results?
 
 ```{r include=FALSE}
-image <- file.path(local_root, "images/qgis_shot_sg2_extended_2.png")
+image <- file.path(local_root, "images/qgis_shot_sg2_extended_3.png")
 image_exists <- file.exists(image)
 ```
 

--- a/src/update_shallowgroundwater/20_check_result.Rmd
+++ b/src/update_shallowgroundwater/20_check_result.Rmd
@@ -1,7 +1,7 @@
 # Check results
 
 ```{r}
-filepath <- file.path(datapath, "sg2_extended_3.gpkg")
+filepath <- file.path(datapath, "sg2_extended_4.gpkg")
 ```
 
 - Checksums:
@@ -29,7 +29,7 @@ glimpse(pol)
 - Sensible results?
 
 ```{r include=FALSE}
-image <- file.path(local_root, "images/qgis_shot_sg2_extended_3.png")
+image <- file.path(local_root, "images/qgis_shot_sg2_extended_4.png")
 image_exists <- file.exists(image)
 ```
 

--- a/src/update_shallowgroundwater/20_check_result.Rmd
+++ b/src/update_shallowgroundwater/20_check_result.Rmd
@@ -1,7 +1,7 @@
 # Check results
 
 ```{r}
-filepath <- file.path(datapath, "sg2_extended_2.gpkg")
+filepath <- file.path(datapath, "sg2_extended_3.gpkg")
 ```
 
 - Checksums:

--- a/src/update_shallowgroundwater/20_check_result.Rmd
+++ b/src/update_shallowgroundwater/20_check_result.Rmd
@@ -20,6 +20,22 @@ c("xxh64", "md5", "sha256") %>%
 glimpse(pol)
 ```
 
+```{r}
+pol %>% 
+  st_drop_geometry %>% 
+  summary
+```
+
+- Are all attribute combinations unique?
+This is a desirable property: each multipolygon stands for another combination of data origins.
+
+```{r}
+pol %>% 
+  st_drop_geometry %>% 
+  {nrow(.) == nrow(distinct(.))}
+```
+
+
 - Is the CRS conform EPSG:31370?
 
 ```{r} 

--- a/src/update_shallowgroundwater/20_check_result.Rmd
+++ b/src/update_shallowgroundwater/20_check_result.Rmd
@@ -1,7 +1,7 @@
 # Check results
 
 ```{r}
-filepath <- file.path(datapath, "sg_extended_2.gpkg")
+filepath <- file.path(datapath, "sg2_extended_2.gpkg")
 ```
 
 - Checksums:
@@ -29,7 +29,7 @@ glimpse(pol)
 - Sensible results?
 
 ```{r include=FALSE}
-image <- file.path(local_root, "images/qgis_shot_sg_extended_2.png")
+image <- file.path(local_root, "images/qgis_shot_sg2_extended_2.png")
 image_exists <- file.exists(image)
 ```
 
@@ -38,4 +38,3 @@ image_exists <- file.exists(image)
 include_graphics(image)
 ```
 
-This looks better than in a previous trial (`sg_extended.gpkg`: <https://github.com/inbo/n2khab-preprocessing/pull/61>).

--- a/src/update_shallowgroundwater/20_check_result.Rmd
+++ b/src/update_shallowgroundwater/20_check_result.Rmd
@@ -1,7 +1,7 @@
 # Check results
 
 ```{r}
-filepath <- file.path(datapath, output_filename)
+filepath <- file.path(sgpath, output_filename)
 ```
 
 - Checksums:

--- a/src/update_shallowgroundwater/20_check_result.Rmd
+++ b/src/update_shallowgroundwater/20_check_result.Rmd
@@ -1,0 +1,27 @@
+# Check results
+
+```{r}
+filepath <- file.path(datapath, "sg_extended.gpkg")
+```
+
+- Checksums:
+
+```{r}
+c("xxh64", "md5", "sha256") %>% 
+  map_dfr(~tibble(algorithm = ., 
+                  checksum = checksum(filepath, .))) %>% 
+  kable
+```
+
+- Contents:
+
+```{r paged.print=FALSE, warning=FALSE}
+(pol <- read_sf(filepath))
+glimpse(pol)
+```
+
+- Is the CRS conform EPSG:31370?
+
+```{r} 
+ st_crs(pol) == st_crs(31370) 
+```

--- a/src/update_shallowgroundwater/20_check_result.Rmd
+++ b/src/update_shallowgroundwater/20_check_result.Rmd
@@ -25,3 +25,21 @@ glimpse(pol)
 ```{r} 
  st_crs(pol) == st_crs(31370) 
 ```
+
+- Sensible results?
+
+```{r include=FALSE}
+image <- file.path(local_root, "images/qgis_shot.png")
+image_exists <- file.exists(image)
+```
+
+
+```{r eval = image_exists, fig.cap="_Appended new areas, in a QGIS screenshot. Zoomed into a specific area. Light colour = original data source, dark colour = appended area._", out.width='80%'}
+include_graphics(image)
+```
+
+The pattern of locally buffered 'obliggwdep' types is quite dominant in the resulting layer.
+In contrast, the original layer has numerous narrow and small patches of shallow groundwater.
+So these may be too narrow.
+It might be sensible to also add a narrow buffer, e.g. 50 m, around the whole of the original layer.
+Or, obtaining a broader area by being more liberal in the selection of soil types.

--- a/src/update_shallowgroundwater/20_check_result.Rmd
+++ b/src/update_shallowgroundwater/20_check_result.Rmd
@@ -1,7 +1,7 @@
 # Check results
 
 ```{r}
-filepath <- file.path(datapath, "sg2_extended_4.gpkg")
+filepath <- file.path(datapath, output_filename)
 ```
 
 - Checksums:

--- a/src/update_shallowgroundwater/99_sessioninfo.Rmd
+++ b/src/update_shallowgroundwater/99_sessioninfo.Rmd
@@ -1,12 +1,21 @@
 # Used environment
 
 ```{r session-info, results = "asis", echo=FALSE}
-si <- devtools::session_info()
+si <- sessioninfo::session_info()
 p <- si$platform %>%
   do.call(what = "c")
-if ("sf" %in% si$packages$package) p <- c(p, sf_extSoftVersion())
-sprintf("- **%s**:\n %s\n", names(p), p) %>%
-  cat()
+if ("sf" %in% si$packages$package) {
+  p <- c(p, sf_extSoftVersion())
+  names(p)[names(p) == "proj.4"] <- "PROJ"
+}
+if ("rgrass7" %in% si$packages$package) {
+  p <- c(p, GRASS = link2GI::findGRASS()[1, "version"])
+}
+if ("qgisprocess" %in% si$packages$package) {
+  p <- c(p, QGIS = qgis_version())
+}
+sprintf("- **%s**: %s\n", names(p), p) %>%
+  cat(sep = "")
 ```
 
 ```{r results = "asis", echo=FALSE}

--- a/src/update_shallowgroundwater/99_sessioninfo.Rmd
+++ b/src/update_shallowgroundwater/99_sessioninfo.Rmd
@@ -1,0 +1,19 @@
+# Used environment
+
+```{r session-info, results = "asis", echo=FALSE}
+si <- devtools::session_info()
+p <- si$platform %>%
+  do.call(what = "c")
+if ("sf" %in% si$packages$package) p <- c(p, sf_extSoftVersion())
+sprintf("- **%s**:\n %s\n", names(p), p) %>%
+  cat()
+```
+
+```{r results = "asis", echo=FALSE}
+si$packages %>%
+    as_tibble %>%
+    select(package, loadedversion, date, source) %>%
+pander::pandoc.table(caption = "(\\#tab:sessioninfo)Loaded R packages",
+                     split.table = Inf)
+```
+

--- a/src/update_shallowgroundwater/_bookdown.yml
+++ b/src/update_shallowgroundwater/_bookdown.yml
@@ -1,4 +1,4 @@
-book_filename: "generating_habitatquarries.Rmd"
+book_filename: "updating_shallowgroundwater.Rmd"
 new_session: FALSE
 rmd_files: # specifies the order of Rmd files; NOT needed when you use index.Rmd and an alphabetical order for other Rmd files
     # - index.Rmd

--- a/src/update_shallowgroundwater/_bookdown.yml
+++ b/src/update_shallowgroundwater/_bookdown.yml
@@ -1,0 +1,4 @@
+book_filename: "generating_habitatquarries.Rmd"
+new_session: FALSE
+rmd_files: # specifies the order of Rmd files; NOT needed when you use index.Rmd and an alphabetical order for other Rmd files
+    # - index.Rmd

--- a/src/update_shallowgroundwater/index.Rmd
+++ b/src/update_shallowgroundwater/index.Rmd
@@ -17,7 +17,8 @@ params:
   union_sg: FALSE
   overwrite_sg_extended: TRUE
   buffer_obliggwdep: 100
-  output_filename: "sg2_extended_4.gpkg"
+  input_layername: "ZOG_20211129_diss"
+  output_filename: "sg_20211129_extended.gpkg"
 output:
   bookdown::html_document2:
     code_folding: hide
@@ -51,7 +52,7 @@ library(future)
 
 # ISO8601 timestamp to set as fixed value in the GeoPackage 
 # (to be UPDATED to the actual creation date; at least update for each version):
-Sys.setenv(OGR_CURRENT_DATE = "2021-10-15T00:00:00.000Z")
+Sys.setenv(OGR_CURRENT_DATE = "2021-12-08T00:00:00.000Z")
 # This is used to keep results reproducible, as the timestamp is otherwise
 # updated each time.
 # Above environment variable OGR_CURRENT_DATE is used by the GDAL driver.

--- a/src/update_shallowgroundwater/index.Rmd
+++ b/src/update_shallowgroundwater/index.Rmd
@@ -13,6 +13,7 @@ documentclass: "article"
 site: bookdown::bookdown_site
 params:
   rewrite_intermediate_aoi_files: TRUE
+  consider_sg_as_new: TRUE
   union_sg: FALSE
   overwrite_sg_extended: TRUE
   buffer_obliggwdep: 100

--- a/src/update_shallowgroundwater/index.Rmd
+++ b/src/update_shallowgroundwater/index.Rmd
@@ -12,7 +12,6 @@ fontsize: 11pt
 documentclass: "article"
 site: bookdown::bookdown_site
 params:
-  gisbase_grass: !r if (.Platform$OS.type == "windows") link2GI::paramGRASSw()$gisbase_GRASS[1] else link2GI::paramGRASSx()$gisbase_GRASS[1]
   rewrite_intermediate_files: TRUE
   overwrite_sg_extended: TRUE
   buffer_obliggwdep: 100
@@ -55,15 +54,6 @@ Sys.setenv(OGR_CURRENT_DATE = "2021-08-05T00:00:00.000Z")
 # The time precision (milliseconds) & timezone (UTC, denoted by 'Z') is
 # needed to meet Requirement 15 of the GeoPackage standard (version 1.2.1 & 1.3).
 
-if (.Platform$OS.type == "unix") {
-  Sys.setenv(GRASS_PYTHON = system("which python3", intern = TRUE))
-}
-gisbase_grass <- 
-  if (interactive()) {
-    if (.Platform$OS.type == "windows") link2GI::paramGRASSw()$gisbase_GRASS[1] else {
-      link2GI::paramGRASSx()$gisbase_GRASS[1]
-    }
-  } else params$gisbase_grass
 opts_chunk$set(
   echo = TRUE,
   dpi = 300

--- a/src/update_shallowgroundwater/index.Rmd
+++ b/src/update_shallowgroundwater/index.Rmd
@@ -31,6 +31,7 @@ output:
 ---
 
 ```{r setup, include=FALSE}
+renv::restore()
 library(sf)
 library(units)
 library(dplyr)

--- a/src/update_shallowgroundwater/index.Rmd
+++ b/src/update_shallowgroundwater/index.Rmd
@@ -62,18 +62,6 @@ opts_chunk$set(
 
 **Note: this is a bookdown project, supposed to be run from within the `src/update_shallowgroundwater` subfolder. You can use the `update_shallowgroundwater.Rproj` RStudio project file in this subfolder to run it.**
 
-```{r}
-# Function to aid in GRASS processing
-execshell <- function(commandstring, intern = FALSE) {
-    if (.Platform$OS.type == "windows") {
-        res <- shell(commandstring, intern = TRUE)
-    } else {
-        res <- system(commandstring, intern = TRUE)
-    }
-    if (!intern) cat(res, sep = "\n") else return(res)
-}
-```
-
 
 
 

--- a/src/update_shallowgroundwater/index.Rmd
+++ b/src/update_shallowgroundwater/index.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Updating the raw data source shallow groundwater"
+title: "Updating the raw data source `shallowgroundwater`"
 # subtitle: "x"
 date: "`r lubridate::now()`"
 link-citations: true

--- a/src/update_shallowgroundwater/index.Rmd
+++ b/src/update_shallowgroundwater/index.Rmd
@@ -40,8 +40,8 @@ library(googledrive)
 library(ggplot2)
 library(mapview)
 library(n2khab)
-library(rgrass7)
 library(qgisprocess)
+library(future)
 if (.Platform$OS.type == "unix") {
   Sys.setenv(GRASS_PYTHON = system("which python3", intern = TRUE))
 }

--- a/src/update_shallowgroundwater/index.Rmd
+++ b/src/update_shallowgroundwater/index.Rmd
@@ -13,6 +13,7 @@ documentclass: "article"
 site: bookdown::bookdown_site
 params:
   rewrite_intermediate_files: TRUE
+  union_sg: FALSE
   overwrite_sg_extended: TRUE
   buffer_obliggwdep: 100
   buffer_areas: 50

--- a/src/update_shallowgroundwater/index.Rmd
+++ b/src/update_shallowgroundwater/index.Rmd
@@ -52,7 +52,7 @@ library(future)
 
 # ISO8601 timestamp to set as fixed value in the GeoPackage 
 # (to be UPDATED to the actual creation date; at least update for each version):
-Sys.setenv(OGR_CURRENT_DATE = "2021-12-08T00:00:00.000Z")
+Sys.setenv(OGR_CURRENT_DATE = "2021-12-13T00:00:00.000Z")
 # This is used to keep results reproducible, as the timestamp is otherwise
 # updated each time.
 # Above environment variable OGR_CURRENT_DATE is used by the GDAL driver.

--- a/src/update_shallowgroundwater/index.Rmd
+++ b/src/update_shallowgroundwater/index.Rmd
@@ -49,7 +49,7 @@ library(future)
 
 # ISO8601 timestamp to set as fixed value in the GeoPackage 
 # (to be UPDATED to the actual creation date; at least update for each version):
-Sys.setenv(OGR_CURRENT_DATE = "2021-08-09T00:00:00.000Z")
+Sys.setenv(OGR_CURRENT_DATE = "2021-10-15T00:00:00.000Z")
 # This is used to keep results reproducible, as the timestamp is otherwise
 # updated each time.
 # Above environment variable OGR_CURRENT_DATE is used by the GDAL driver.

--- a/src/update_shallowgroundwater/index.Rmd
+++ b/src/update_shallowgroundwater/index.Rmd
@@ -17,6 +17,7 @@ params:
   union_sg: FALSE
   overwrite_sg_extended: TRUE
   buffer_obliggwdep: 100
+  output_filename: "sg2_extended_4.gpkg"
 output:
   bookdown::html_document2:
     code_folding: hide

--- a/src/update_shallowgroundwater/index.Rmd
+++ b/src/update_shallowgroundwater/index.Rmd
@@ -13,6 +13,7 @@ documentclass: "article"
 site: bookdown::bookdown_site
 params:
   gisbase_grass: !r if (.Platform$OS.type == "windows") link2GI::paramGRASSw()$gisbase_GRASS[1] else link2GI::paramGRASSx()$gisbase_GRASS[1]
+  overwrite_sg_extended: TRUE
 output:
   bookdown::html_document2:
     code_folding: hide
@@ -42,6 +43,16 @@ library(mapview)
 library(n2khab)
 library(qgisprocess)
 library(future)
+
+# ISO8601 timestamp to set as fixed value in the GeoPackage 
+# (to be UPDATED to the actual creation date; at least update for each version):
+Sys.setenv(OGR_CURRENT_DATE = "2021-08-05T00:00:00.000Z")
+# This is used to keep results reproducible, as the timestamp is otherwise
+# updated each time.
+# Above environment variable OGR_CURRENT_DATE is used by the GDAL driver.
+# The time precision (milliseconds) & timezone (UTC, denoted by 'Z') is
+# needed to meet Requirement 15 of the GeoPackage standard (version 1.2.1 & 1.3).
+
 if (.Platform$OS.type == "unix") {
   Sys.setenv(GRASS_PYTHON = system("which python3", intern = TRUE))
 }

--- a/src/update_shallowgroundwater/index.Rmd
+++ b/src/update_shallowgroundwater/index.Rmd
@@ -17,7 +17,6 @@ params:
   union_sg: FALSE
   overwrite_sg_extended: TRUE
   buffer_obliggwdep: 100
-  buffer_areas: 50
 output:
   bookdown::html_document2:
     code_folding: hide

--- a/src/update_shallowgroundwater/index.Rmd
+++ b/src/update_shallowgroundwater/index.Rmd
@@ -13,6 +13,7 @@ documentclass: "article"
 site: bookdown::bookdown_site
 params:
   gisbase_grass: !r if (.Platform$OS.type == "windows") link2GI::paramGRASSw()$gisbase_GRASS[1] else link2GI::paramGRASSx()$gisbase_GRASS[1]
+  rewrite_intermediate_files: TRUE
   overwrite_sg_extended: TRUE
 output:
   bookdown::html_document2:

--- a/src/update_shallowgroundwater/index.Rmd
+++ b/src/update_shallowgroundwater/index.Rmd
@@ -18,7 +18,7 @@ params:
   overwrite_sg_extended: TRUE
   buffer_obliggwdep: 100
   input_layername: "ZOG_20211129_diss"
-  output_filename: "sg_20211129_extended.gpkg"
+  output_filename: "shallowgroundwater.gpkg"
 output:
   bookdown::html_document2:
     code_folding: hide

--- a/src/update_shallowgroundwater/index.Rmd
+++ b/src/update_shallowgroundwater/index.Rmd
@@ -12,7 +12,7 @@ fontsize: 11pt
 documentclass: "article"
 site: bookdown::bookdown_site
 params:
-  rewrite_intermediate_files: TRUE
+  rewrite_intermediate_aoi_files: TRUE
   union_sg: FALSE
   overwrite_sg_extended: TRUE
   buffer_obliggwdep: 100

--- a/src/update_shallowgroundwater/index.Rmd
+++ b/src/update_shallowgroundwater/index.Rmd
@@ -1,0 +1,77 @@
+---
+title: "Updating the raw data source shallow groundwater"
+# subtitle: "x"
+date: "`r lubridate::now()`"
+link-citations: true
+linkcolor: link.colour
+citecolor: link.colour
+urlcolor: link.colour
+geometry: margin=1in
+mainfont: "Calibri"
+fontsize: 11pt
+documentclass: "article"
+site: bookdown::bookdown_site
+params:
+  gisbase_grass: !r if (.Platform$OS.type == "windows") link2GI::paramGRASSw()$gisbase_GRASS[1] else link2GI::paramGRASSx()$gisbase_GRASS[1]
+output:
+  bookdown::html_document2:
+    code_folding: hide
+    keep_md: TRUE
+    number_sections: yes
+    fig_caption: yes
+    df_print: paged
+    toc: TRUE
+    toc_float:
+      collapsed: FALSE
+      smooth_scroll: FALSE
+    includes:
+        in_header: ../header.html
+---
+
+```{r setup, include=FALSE}
+library(sf)
+library(units)
+library(dplyr)
+library(stringr)
+library(purrr)
+library(knitr)
+library(rprojroot)
+library(googledrive)
+library(ggplot2)
+library(mapview)
+library(n2khab)
+library(rgrass7)
+library(qgisprocess)
+if (.Platform$OS.type == "unix") {
+  Sys.setenv(GRASS_PYTHON = system("which python3", intern = TRUE))
+}
+gisbase_grass <- 
+  if (interactive()) {
+    if (.Platform$OS.type == "windows") link2GI::paramGRASSw()$gisbase_GRASS[1] else {
+      link2GI::paramGRASSx()$gisbase_GRASS[1]
+    }
+  } else params$gisbase_grass
+opts_chunk$set(
+  echo = TRUE,
+  dpi = 300
+)
+```
+
+**Note: this is a bookdown project, supposed to be run from within the `src/update_shallowgroundwater` subfolder. You can use the `update_shallowgroundwater.Rproj` RStudio project file in this subfolder to run it.**
+
+```{r}
+# Function to aid in GRASS processing
+execshell <- function(commandstring, intern = FALSE) {
+    if (.Platform$OS.type == "windows") {
+        res <- shell(commandstring, intern = TRUE)
+    } else {
+        res <- system(commandstring, intern = TRUE)
+    }
+    if (!intern) cat(res, sep = "\n") else return(res)
+}
+```
+
+
+
+
+

--- a/src/update_shallowgroundwater/index.Rmd
+++ b/src/update_shallowgroundwater/index.Rmd
@@ -15,6 +15,7 @@ params:
   gisbase_grass: !r if (.Platform$OS.type == "windows") link2GI::paramGRASSw()$gisbase_GRASS[1] else link2GI::paramGRASSx()$gisbase_GRASS[1]
   rewrite_intermediate_files: TRUE
   overwrite_sg_extended: TRUE
+  buffer_obliggwdep: 100
 output:
   bookdown::html_document2:
     code_folding: hide

--- a/src/update_shallowgroundwater/renv.lock
+++ b/src/update_shallowgroundwater/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.1.0",
+    "Version": "4.1.2",
     "Repositories": [
       {
         "Name": "CRAN",

--- a/src/update_shallowgroundwater/renv.lock
+++ b/src/update_shallowgroundwater/renv.lock
@@ -1,0 +1,1105 @@
+{
+  "R": {
+    "Version": "4.1.0",
+    "Repositories": [
+      {
+        "Name": "CRAN",
+        "URL": "https://cloud.r-project.org"
+      },
+      {
+        "Name": "INLA",
+        "URL": "https://inla.r-inla-download.org/R/stable"
+      }
+    ]
+  },
+  "Packages": {
+    "DBI": {
+      "Package": "DBI",
+      "Version": "1.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "030aaec5bc6553f35347cbb1e70b1a17"
+    },
+    "KernSmooth": {
+      "Package": "KernSmooth",
+      "Version": "2.23-20",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "8dcfa99b14c296bc9f1fd64d52fd3ce7"
+    },
+    "MASS": {
+      "Package": "MASS",
+      "Version": "7.3-54",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "0e59129db205112e3963904db67fd0dc"
+    },
+    "Matrix": {
+      "Package": "Matrix",
+      "Version": "1.3-4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "4ed05e9c9726267e4a5872e09c04587c"
+    },
+    "R.methodsS3": {
+      "Package": "R.methodsS3",
+      "Version": "1.8.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "4bf6453323755202d5909697b6f7c109"
+    },
+    "R.oo": {
+      "Package": "R.oo",
+      "Version": "1.24.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "5709328352717e2f0a9c012be8a97554"
+    },
+    "R.utils": {
+      "Package": "R.utils",
+      "Version": "2.10.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a9e316277ff12a43997266f2f6567780"
+    },
+    "R6": {
+      "Package": "R6",
+      "Version": "2.5.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "b203113193e70978a696b2809525649d"
+    },
+    "RColorBrewer": {
+      "Package": "RColorBrewer",
+      "Version": "1.1-2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "e031418365a7f7a766181ab5a41a5716"
+    },
+    "Rcpp": {
+      "Package": "Rcpp",
+      "Version": "1.0.6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "dbb5e436998a7eba5a9d682060533338"
+    },
+    "askpass": {
+      "Package": "askpass",
+      "Version": "1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "e8a22846fff485f0be3770c2da758713"
+    },
+    "assertthat": {
+      "Package": "assertthat",
+      "Version": "0.2.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "50c838a310445e954bc13f26f26a6ecf"
+    },
+    "base64enc": {
+      "Package": "base64enc",
+      "Version": "0.1-3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "543776ae6848fde2f48ff3816d0628bc"
+    },
+    "bookdown": {
+      "Package": "bookdown",
+      "Version": "0.22",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "8fb0b67dfdf9d751fc93cb0036def3cc"
+    },
+    "brew": {
+      "Package": "brew",
+      "Version": "1.0-6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "92a5f887f9ae3035ac7afde22ba73ee9"
+    },
+    "brio": {
+      "Package": "brio",
+      "Version": "1.1.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "2f01e16ff9571fe70381c7b9ae560dc4"
+    },
+    "cachem": {
+      "Package": "cachem",
+      "Version": "1.0.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "5346f76a33eb7417812c270b04a5581b"
+    },
+    "callr": {
+      "Package": "callr",
+      "Version": "3.7.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "461aa75a11ce2400245190ef5d3995df"
+    },
+    "class": {
+      "Package": "class",
+      "Version": "7.3-19",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "1593b7beb067c8381c0d24e38bd778e0"
+    },
+    "classInt": {
+      "Package": "classInt",
+      "Version": "0.4-3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "17bdfa3c51df4a6c82484d13b11fb380"
+    },
+    "cli": {
+      "Package": "cli",
+      "Version": "2.5.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a94ba44cee3ea571e813721e64184172"
+    },
+    "clipr": {
+      "Package": "clipr",
+      "Version": "0.7.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ebaa97ac99cc2daf04e77eecc7b781d7"
+    },
+    "codetools": {
+      "Package": "codetools",
+      "Version": "0.2-18",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "019388fc48e48b3da0d3a76ff94608a8"
+    },
+    "colorspace": {
+      "Package": "colorspace",
+      "Version": "2.0-1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6cab523af06ac301e7a40c5529d45882"
+    },
+    "commonmark": {
+      "Package": "commonmark",
+      "Version": "1.7",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "0f22be39ec1d141fd03683c06f3a6e67"
+    },
+    "cpp11": {
+      "Package": "cpp11",
+      "Version": "0.2.7",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "730eebcc741a5c36761f7d4d0f5e37b8"
+    },
+    "crayon": {
+      "Package": "crayon",
+      "Version": "1.4.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "e75525c55c70e5f4f78c9960a4b402e9"
+    },
+    "credentials": {
+      "Package": "credentials",
+      "Version": "1.3.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a96728288c75a814c900af9da84387be"
+    },
+    "crosstalk": {
+      "Package": "crosstalk",
+      "Version": "1.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "2b06f9e415a62b6762e4b8098d2aecbc"
+    },
+    "curl": {
+      "Package": "curl",
+      "Version": "4.3.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "c5e68405893f030f139f6d6675eac675"
+    },
+    "desc": {
+      "Package": "desc",
+      "Version": "1.3.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "b6963166f7f10b970af1006c462ce6cd"
+    },
+    "devtools": {
+      "Package": "devtools",
+      "Version": "2.4.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "048d0b914d2cea61f440d35dd3cbddac"
+    },
+    "diffobj": {
+      "Package": "diffobj",
+      "Version": "0.3.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "feb5b7455eba422a2c110bb89852e6a3"
+    },
+    "digest": {
+      "Package": "digest",
+      "Version": "0.6.27",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a0cbe758a531d054b537d16dff4d58a1"
+    },
+    "dplyr": {
+      "Package": "dplyr",
+      "Version": "1.0.6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "19e84500b64bc7e589cb1e2550e25832"
+    },
+    "e1071": {
+      "Package": "e1071",
+      "Version": "1.7-7",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "7426a46e210d9f3815ed793e7112f582"
+    },
+    "ellipsis": {
+      "Package": "ellipsis",
+      "Version": "0.3.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "bb0eec2fe32e88d9e2836c2f73ea2077"
+    },
+    "evaluate": {
+      "Package": "evaluate",
+      "Version": "0.14",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ec8ca05cffcc70569eaaad8469d2a3a7"
+    },
+    "fansi": {
+      "Package": "fansi",
+      "Version": "0.5.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "d447b40982c576a72b779f0a3b3da227"
+    },
+    "farver": {
+      "Package": "farver",
+      "Version": "2.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "c98eb5133d9cb9e1622b8691487f11bb"
+    },
+    "fastmap": {
+      "Package": "fastmap",
+      "Version": "1.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "77bd60a6157420d4ffa93b27cf6a58b8"
+    },
+    "forcats": {
+      "Package": "forcats",
+      "Version": "0.5.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "81c3244cab67468aac4c60550832655d"
+    },
+    "fs": {
+      "Package": "fs",
+      "Version": "1.5.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "44594a07a42e5f91fac9f93fda6d0109"
+    },
+    "future": {
+      "Package": "future",
+      "Version": "1.21.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "f25fad6bee82b7ab01f055e2d813b96f"
+    },
+    "gargle": {
+      "Package": "gargle",
+      "Version": "1.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "bc3bc77ea458de0a6efe94e8e7e9c641"
+    },
+    "generics": {
+      "Package": "generics",
+      "Version": "0.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "4d243a9c10b00589889fe32314ffd902"
+    },
+    "geojsonsf": {
+      "Package": "geojsonsf",
+      "Version": "2.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "8bf70c1328f68761115943b68e565dc6"
+    },
+    "geometries": {
+      "Package": "geometries",
+      "Version": "0.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "be29054e97e756ade56d13a89c6d5243"
+    },
+    "gert": {
+      "Package": "gert",
+      "Version": "1.3.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "56f398846cd40937be6b435a66bd3f37"
+    },
+    "ggplot2": {
+      "Package": "ggplot2",
+      "Version": "3.3.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "3eb6477d01eb5bbdc03f7d5f70f2733e"
+    },
+    "gh": {
+      "Package": "gh",
+      "Version": "1.3.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "38c2580abbda249bd6afeec00d14f531"
+    },
+    "git2r": {
+      "Package": "git2r",
+      "Version": "0.28.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "f64fd34026f6025de71a4354800e6d79"
+    },
+    "git2rdata": {
+      "Package": "git2rdata",
+      "Version": "0.3.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "42391cea59cc785157b9fefaf9a223ef"
+    },
+    "gitcreds": {
+      "Package": "gitcreds",
+      "Version": "0.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "f3aefccc1cc50de6338146b62f115de8"
+    },
+    "globals": {
+      "Package": "globals",
+      "Version": "0.14.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "eca8023ed5ca6372479ebb9b3207f5ae"
+    },
+    "glue": {
+      "Package": "glue",
+      "Version": "1.4.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6efd734b14c6471cfe443345f3e35e29"
+    },
+    "googledrive": {
+      "Package": "googledrive",
+      "Version": "1.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "79ba5d18133290a69b7c135dc3dfef1a"
+    },
+    "gridExtra": {
+      "Package": "gridExtra",
+      "Version": "2.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "7d7f283939f563670a697165b2cf5560"
+    },
+    "gtable": {
+      "Package": "gtable",
+      "Version": "0.3.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ac5c6baf7822ce8732b343f14c072c4d"
+    },
+    "highr": {
+      "Package": "highr",
+      "Version": "0.9",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "8eb36c8125038e648e5d111c0d7b2ed4"
+    },
+    "htmltools": {
+      "Package": "htmltools",
+      "Version": "0.5.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "af2c2531e55df5cf230c4b5444fc973c"
+    },
+    "htmlwidgets": {
+      "Package": "htmlwidgets",
+      "Version": "1.5.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6fdaa86d0700f8b3e92ee3c445a5a10d"
+    },
+    "httpuv": {
+      "Package": "httpuv",
+      "Version": "1.6.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "54344a78aae37bc6ef39b1240969df8e"
+    },
+    "httr": {
+      "Package": "httr",
+      "Version": "1.4.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a525aba14184fec243f9eaec62fbed43"
+    },
+    "ini": {
+      "Package": "ini",
+      "Version": "0.3.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6154ec2223172bce8162d4153cda21f7"
+    },
+    "isoband": {
+      "Package": "isoband",
+      "Version": "0.2.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "b2008df40fb297e3fef135c7e8eeec1a"
+    },
+    "jsonify": {
+      "Package": "jsonify",
+      "Version": "1.2.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "f435875f0eb7de52ade944ed82ee9089"
+    },
+    "jsonlite": {
+      "Package": "jsonlite",
+      "Version": "1.7.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "98138e0994d41508c7a6b84a0600cfcb"
+    },
+    "knitr": {
+      "Package": "knitr",
+      "Version": "1.33",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "0bc1b5da1b0eb07cd4b727e95e9ff0b8"
+    },
+    "labeling": {
+      "Package": "labeling",
+      "Version": "0.4.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "3d5108641f47470611a32d0bdf357a72"
+    },
+    "later": {
+      "Package": "later",
+      "Version": "1.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "b61890ae77fea19fc8acadd25db70aa4"
+    },
+    "lattice": {
+      "Package": "lattice",
+      "Version": "0.20-44",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "f36bf1a849d9106dc2af72e501f9de41"
+    },
+    "lazyeval": {
+      "Package": "lazyeval",
+      "Version": "0.2.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "d908914ae53b04d4c0c0fd72ecc35370"
+    },
+    "leafem": {
+      "Package": "leafem",
+      "Version": "0.1.6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "39682b851cfb151d02be19c5575bdc00"
+    },
+    "leaflet": {
+      "Package": "leaflet",
+      "Version": "2.0.4.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "e3d73becdeb92754d27172d278cbf61d"
+    },
+    "leaflet.providers": {
+      "Package": "leaflet.providers",
+      "Version": "1.9.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "d3082a7beac4a1aeb96100ff06265d7e"
+    },
+    "leafpop": {
+      "Package": "leafpop",
+      "Version": "0.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "0c1e9e9a79598ec5acb1820d1948dae8"
+    },
+    "lifecycle": {
+      "Package": "lifecycle",
+      "Version": "1.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "3471fb65971f1a7b2d4ae7848cf2db8d"
+    },
+    "link2GI": {
+      "Package": "link2GI",
+      "Version": "0.4-5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "591bd5deb49c22dee02bbab83877858f"
+    },
+    "listenv": {
+      "Package": "listenv",
+      "Version": "0.8.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "0bde42ee282efb18c7c4e63822f5b4f7"
+    },
+    "lubridate": {
+      "Package": "lubridate",
+      "Version": "1.7.10",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "1ebfdc8a3cfe8fe19184f5481972b092"
+    },
+    "lwgeom": {
+      "Package": "lwgeom",
+      "Version": "0.2-6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "1db8e70ff9db156a176b642e417030ae"
+    },
+    "magrittr": {
+      "Package": "magrittr",
+      "Version": "2.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "41287f1ac7d28a92f0a286ed507928d3"
+    },
+    "mapview": {
+      "Package": "mapview",
+      "Version": "2.10.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "70cc642e96759a1b81f7528a46aeb7a7"
+    },
+    "markdown": {
+      "Package": "markdown",
+      "Version": "1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "61e4a10781dd00d7d81dd06ca9b94e95"
+    },
+    "memoise": {
+      "Package": "memoise",
+      "Version": "2.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a0bc51650201a56d00a4798523cc91b3"
+    },
+    "mgcv": {
+      "Package": "mgcv",
+      "Version": "1.8-36",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "93cc747b0e1ad882a4570463c3575c23"
+    },
+    "mime": {
+      "Package": "mime",
+      "Version": "0.10",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "26fa77e707223e1ce042b2b5d09993dc"
+    },
+    "munsell": {
+      "Package": "munsell",
+      "Version": "0.5.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6dfe8bf774944bd5595785e3229d8771"
+    },
+    "n2khab": {
+      "Package": "n2khab",
+      "Version": "0.5.0",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteUsername": "inbo",
+      "RemoteRepo": "n2khab",
+      "RemoteRef": "master",
+      "RemoteSha": "711a88aa9aa54780b83c6d785f2404a12e4456a7",
+      "Hash": "ee71038ad9b8da262617ffc582fff479"
+    },
+    "nlme": {
+      "Package": "nlme",
+      "Version": "3.1-152",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "35de1ce639f20b5e10f7f46260730c65"
+    },
+    "openssl": {
+      "Package": "openssl",
+      "Version": "1.4.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "f4dbc5a47fd93d3415249884d31d6791"
+    },
+    "pander": {
+      "Package": "pander",
+      "Version": "0.6.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "121198ce37b5a6b5227edc5a38223da4"
+    },
+    "parallelly": {
+      "Package": "parallelly",
+      "Version": "1.27.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "e38aabb0dde91e5622b83747b559bfc2"
+    },
+    "pillar": {
+      "Package": "pillar",
+      "Version": "1.6.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "8672ae02bd20f6479bce2d06c7ff1401"
+    },
+    "pkgbuild": {
+      "Package": "pkgbuild",
+      "Version": "1.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "725fcc30222d4d11ec68efb8ff11a9af"
+    },
+    "pkgconfig": {
+      "Package": "pkgconfig",
+      "Version": "2.0.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "01f28d4278f15c76cddbea05899c5d6f"
+    },
+    "pkgload": {
+      "Package": "pkgload",
+      "Version": "1.2.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "463642747f81879e6752485aefb831cf"
+    },
+    "plyr": {
+      "Package": "plyr",
+      "Version": "1.8.6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ec0e5ab4e5f851f6ef32cd1d1984957f"
+    },
+    "png": {
+      "Package": "png",
+      "Version": "0.1-7",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "03b7076c234cb3331288919983326c55"
+    },
+    "praise": {
+      "Package": "praise",
+      "Version": "1.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a555924add98c99d2f411e37e7d25e9f"
+    },
+    "prettyunits": {
+      "Package": "prettyunits",
+      "Version": "1.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "95ef9167b75dde9d2ccc3c7528393e7e"
+    },
+    "processx": {
+      "Package": "processx",
+      "Version": "3.5.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "0cbca2bc4d16525d009c4dbba156b37c"
+    },
+    "promises": {
+      "Package": "promises",
+      "Version": "1.2.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "4ab2c43adb4d4699cf3690acd378d75d"
+    },
+    "proxy": {
+      "Package": "proxy",
+      "Version": "0.4-26",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "50b405c6419e921b9e9360cc9ebbcf2d"
+    },
+    "ps": {
+      "Package": "ps",
+      "Version": "1.6.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "32620e2001c1dce1af49c49dccbb9420"
+    },
+    "purrr": {
+      "Package": "purrr",
+      "Version": "0.3.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "97def703420c8ab10d8f0e6c72101e02"
+    },
+    "qgisprocess": {
+      "Package": "qgisprocess",
+      "Version": "0.0.0.9000",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteRepo": "qgisprocess",
+      "RemoteUsername": "paleolimbot",
+      "RemoteRef": "HEAD",
+      "RemoteSha": "2b61d6fca5e911abc5155d28bba3f9f6c8dc834a",
+      "Hash": "b2bf0408d0586b42e716bb8eac4f26ba"
+    },
+    "rapidjsonr": {
+      "Package": "rapidjsonr",
+      "Version": "1.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "88b9f48c93d17cdb811b54079a6a414f"
+    },
+    "rappdirs": {
+      "Package": "rappdirs",
+      "Version": "0.3.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "5e3c5dc0b071b21fa128676560dbe94d"
+    },
+    "raster": {
+      "Package": "raster",
+      "Version": "3.4-10",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "1d6398dd08391629b5438f9de172f038"
+    },
+    "rcmdcheck": {
+      "Package": "rcmdcheck",
+      "Version": "1.3.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ed95895886dab6d2a584da45503555da"
+    },
+    "rematch2": {
+      "Package": "rematch2",
+      "Version": "2.1.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "76c9e04c712a05848ae7a23d2f170a40"
+    },
+    "remotes": {
+      "Package": "remotes",
+      "Version": "2.4.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a85ebb35721573b196317b49ddd2dfe4"
+    },
+    "renv": {
+      "Package": "renv",
+      "Version": "0.13.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "079cb1f03ff972b30401ed05623cbe92"
+    },
+    "rlang": {
+      "Package": "rlang",
+      "Version": "0.4.11",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "515f341d3affe0de9e4a7f762efb0456"
+    },
+    "rmarkdown": {
+      "Package": "rmarkdown",
+      "Version": "2.8",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "f518ba47713f92d0d603eec7c6888faf"
+    },
+    "roxygen2": {
+      "Package": "roxygen2",
+      "Version": "7.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "fcd94e00cc409b25d07ca50f7bf339f5"
+    },
+    "rprojroot": {
+      "Package": "rprojroot",
+      "Version": "2.0.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "249d8cd1e74a8f6a26194a91b47f21d1"
+    },
+    "rstudioapi": {
+      "Package": "rstudioapi",
+      "Version": "0.13",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "06c85365a03fdaf699966cc1d3cf53ea"
+    },
+    "rversions": {
+      "Package": "rversions",
+      "Version": "2.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "f88fab00907b312f8b23ec13e2d437cb"
+    },
+    "satellite": {
+      "Package": "satellite",
+      "Version": "1.0.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ee6f12377077643b0822de5130a9f597"
+    },
+    "scales": {
+      "Package": "scales",
+      "Version": "1.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6f76f71042411426ec8df6c54f34e6dd"
+    },
+    "servr": {
+      "Package": "servr",
+      "Version": "0.22",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "8cfe5c1d3a8c8304496ba3034e080405"
+    },
+    "sessioninfo": {
+      "Package": "sessioninfo",
+      "Version": "1.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "308013098befe37484df72c39cf90d6e"
+    },
+    "sf": {
+      "Package": "sf",
+      "Version": "0.9-8",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "d82215b501772c9faadb4dcd71395c7d"
+    },
+    "sfheaders": {
+      "Package": "sfheaders",
+      "Version": "0.4.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "c1bd5fbd6bed3c16a20df15d9bc20c55"
+    },
+    "sp": {
+      "Package": "sp",
+      "Version": "1.4-5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "dfd843ee98246cf932823acf613b05dd"
+    },
+    "stringi": {
+      "Package": "stringi",
+      "Version": "1.6.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "9df5e6f9a7fa11b84adf0429961de66a"
+    },
+    "stringr": {
+      "Package": "stringr",
+      "Version": "1.4.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "0759e6b6c0957edb1311028a49a35e76"
+    },
+    "svglite": {
+      "Package": "svglite",
+      "Version": "2.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "8fb6188960bf0f90996ce52f9c2106ac"
+    },
+    "sys": {
+      "Package": "sys",
+      "Version": "3.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "b227d13e29222b4574486cfcbde077fa"
+    },
+    "systemfonts": {
+      "Package": "systemfonts",
+      "Version": "1.0.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "f2e17ba09737e2e7e2ec40fc1f9b6e08"
+    },
+    "testthat": {
+      "Package": "testthat",
+      "Version": "3.0.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "495e0434d9305716b6a87031570ce109"
+    },
+    "tibble": {
+      "Package": "tibble",
+      "Version": "3.1.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "349b40a9f144516d537c875e786ec8b8"
+    },
+    "tidyr": {
+      "Package": "tidyr",
+      "Version": "1.1.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "450d7dfaedde58e28586b854eeece4fa"
+    },
+    "tidyselect": {
+      "Package": "tidyselect",
+      "Version": "1.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "7243004a708d06d4716717fa1ff5b2fe"
+    },
+    "tinytex": {
+      "Package": "tinytex",
+      "Version": "0.32",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "db9a6f2cf147751322d22c9f6647c7bd"
+    },
+    "units": {
+      "Package": "units",
+      "Version": "0.7-1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "1eb71bc3895bf5a047485c16758c4862"
+    },
+    "usethis": {
+      "Package": "usethis",
+      "Version": "2.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "360e904f9e623286e1a0c6ca0a98c5f6"
+    },
+    "utf8": {
+      "Package": "utf8",
+      "Version": "1.2.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "c3ad47dc6da0751f18ed53c4613e3ac7"
+    },
+    "uuid": {
+      "Package": "uuid",
+      "Version": "0.1-4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "e4169eb989a5d03ccb6b628cad1b1b50"
+    },
+    "vctrs": {
+      "Package": "vctrs",
+      "Version": "0.3.8",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ecf749a1b39ea72bd9b51b76292261f1"
+    },
+    "viridis": {
+      "Package": "viridis",
+      "Version": "0.6.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "424d1285b7372d39806abb19467e4df4"
+    },
+    "viridisLite": {
+      "Package": "viridisLite",
+      "Version": "0.4.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "55e157e2aa88161bdb0754218470d204"
+    },
+    "waldo": {
+      "Package": "waldo",
+      "Version": "0.2.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "20c45f1d511a3f730b7b469f4d11e104"
+    },
+    "webshot": {
+      "Package": "webshot",
+      "Version": "0.5.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "e99d80ad34457a4853674e89d5e806de"
+    },
+    "whisker": {
+      "Package": "whisker",
+      "Version": "0.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ca970b96d894e90397ed20637a0c1bbe"
+    },
+    "withr": {
+      "Package": "withr",
+      "Version": "2.4.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ad03909b44677f930fa156d47d7a3aeb"
+    },
+    "xfun": {
+      "Package": "xfun",
+      "Version": "0.23",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "791a57f43c887111490851dcd166d344"
+    },
+    "xml2": {
+      "Package": "xml2",
+      "Version": "1.3.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "d4d71a75dd3ea9eb5fa28cc21f9585e2"
+    },
+    "xopen": {
+      "Package": "xopen",
+      "Version": "1.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6c85f015dee9cc7710ddd20f86881f58"
+    },
+    "yaml": {
+      "Package": "yaml",
+      "Version": "2.2.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "2826c5d9efb0a88f657c7a679c7106db"
+    },
+    "zip": {
+      "Package": "zip",
+      "Version": "2.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "c7eef2996ac270a18c2715c997a727c5"
+    }
+  }
+}

--- a/src/update_shallowgroundwater/renv.lock
+++ b/src/update_shallowgroundwater/renv.lock
@@ -111,6 +111,13 @@
       "Repository": "CRAN",
       "Hash": "8fb0b67dfdf9d751fc93cb0036def3cc"
     },
+    "boot": {
+      "Package": "boot",
+      "Version": "1.3-28",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "0baa960e3b49c6176a4f42addcbacc59"
+    },
     "brew": {
       "Package": "brew",
       "Version": "1.0-6",
@@ -166,6 +173,13 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "ebaa97ac99cc2daf04e77eecc7b781d7"
+    },
+    "cluster": {
+      "Package": "cluster",
+      "Version": "2.1.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ce49bfe5bc0b3ecd43a01fe1b01c2243"
     },
     "codetools": {
       "Package": "codetools",
@@ -306,6 +320,13 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "81c3244cab67468aac4c60550832655d"
+    },
+    "foreign": {
+      "Package": "foreign",
+      "Version": "0.8-81",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "74628ea7a3be5ee8a7b5bb0a8e84882e"
     },
     "fs": {
       "Package": "fs",
@@ -655,6 +676,13 @@
       "Repository": "CRAN",
       "Hash": "35de1ce639f20b5e10f7f46260730c65"
     },
+    "nnet": {
+      "Package": "nnet",
+      "Version": "7.3-16",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "3a3dc184000bc9e6c145c4dbde4dd702"
+    },
     "openssl": {
       "Package": "openssl",
       "Version": "1.4.4",
@@ -849,6 +877,13 @@
       "Repository": "CRAN",
       "Hash": "fcd94e00cc409b25d07ca50f7bf339f5"
     },
+    "rpart": {
+      "Package": "rpart",
+      "Version": "4.1-15",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "9787c1fcb680e655d062e7611cadf78e"
+    },
     "rprojroot": {
       "Package": "rprojroot",
       "Version": "2.0.2",
@@ -919,6 +954,13 @@
       "Repository": "CRAN",
       "Hash": "dfd843ee98246cf932823acf613b05dd"
     },
+    "spatial": {
+      "Package": "spatial",
+      "Version": "7.3-14",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a7341b0231ca84a0323982d5ae5a4300"
+    },
     "stringi": {
       "Package": "stringi",
       "Version": "1.6.2",
@@ -932,6 +974,13 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "0759e6b6c0957edb1311028a49a35e76"
+    },
+    "survival": {
+      "Package": "survival",
+      "Version": "3.2-11",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "f4d706b25d640dbaeb56d9c9b6ce9a22"
     },
     "svglite": {
       "Package": "svglite",

--- a/src/update_shallowgroundwater/renv/.gitignore
+++ b/src/update_shallowgroundwater/renv/.gitignore
@@ -1,0 +1,5 @@
+library/
+local/
+lock/
+python/
+staging/

--- a/src/update_shallowgroundwater/renv/activate.R
+++ b/src/update_shallowgroundwater/renv/activate.R
@@ -1,0 +1,654 @@
+
+local({
+
+  # the requested version of renv
+  version <- "0.13.2"
+
+  # the project directory
+  project <- getwd()
+
+  # avoid recursion
+  if (!is.na(Sys.getenv("RENV_R_INITIALIZING", unset = NA)))
+    return(invisible(TRUE))
+
+  # signal that we're loading renv during R startup
+  Sys.setenv("RENV_R_INITIALIZING" = "true")
+  on.exit(Sys.unsetenv("RENV_R_INITIALIZING"), add = TRUE)
+
+  # signal that we've consented to use renv
+  options(renv.consent = TRUE)
+
+  # load the 'utils' package eagerly -- this ensures that renv shims, which
+  # mask 'utils' packages, will come first on the search path
+  library(utils, lib.loc = .Library)
+
+  # check to see if renv has already been loaded
+  if ("renv" %in% loadedNamespaces()) {
+
+    # if renv has already been loaded, and it's the requested version of renv,
+    # nothing to do
+    spec <- .getNamespaceInfo(.getNamespace("renv"), "spec")
+    if (identical(spec[["version"]], version))
+      return(invisible(TRUE))
+
+    # otherwise, unload and attempt to load the correct version of renv
+    unloadNamespace("renv")
+
+  }
+
+  # load bootstrap tools   
+  bootstrap <- function(version, library) {
+  
+    # attempt to download renv
+    tarball <- tryCatch(renv_bootstrap_download(version), error = identity)
+    if (inherits(tarball, "error"))
+      stop("failed to download renv ", version)
+  
+    # now attempt to install
+    status <- tryCatch(renv_bootstrap_install(version, tarball, library), error = identity)
+    if (inherits(status, "error"))
+      stop("failed to install renv ", version)
+  
+  }
+  
+  renv_bootstrap_tests_running <- function() {
+    getOption("renv.tests.running", default = FALSE)
+  }
+  
+  renv_bootstrap_repos <- function() {
+  
+    # check for repos override
+    repos <- Sys.getenv("RENV_CONFIG_REPOS_OVERRIDE", unset = NA)
+    if (!is.na(repos))
+      return(repos)
+  
+    # if we're testing, re-use the test repositories
+    if (renv_bootstrap_tests_running())
+      return(getOption("renv.tests.repos"))
+  
+    # retrieve current repos
+    repos <- getOption("repos")
+  
+    # ensure @CRAN@ entries are resolved
+    repos[repos == "@CRAN@"] <- getOption(
+      "renv.repos.cran",
+      "https://cloud.r-project.org"
+    )
+  
+    # add in renv.bootstrap.repos if set
+    default <- c(FALLBACK = "https://cloud.r-project.org")
+    extra <- getOption("renv.bootstrap.repos", default = default)
+    repos <- c(repos, extra)
+  
+    # remove duplicates that might've snuck in
+    dupes <- duplicated(repos) | duplicated(names(repos))
+    repos[!dupes]
+  
+  }
+  
+  renv_bootstrap_download <- function(version) {
+  
+    # if the renv version number has 4 components, assume it must
+    # be retrieved via github
+    nv <- numeric_version(version)
+    components <- unclass(nv)[[1]]
+  
+    methods <- if (length(components) == 4L) {
+      list(
+        renv_bootstrap_download_github
+      )
+    } else {
+      list(
+        renv_bootstrap_download_cran_latest,
+        renv_bootstrap_download_cran_archive
+      )
+    }
+  
+    for (method in methods) {
+      path <- tryCatch(method(version), error = identity)
+      if (is.character(path) && file.exists(path))
+        return(path)
+    }
+  
+    stop("failed to download renv ", version)
+  
+  }
+  
+  renv_bootstrap_download_impl <- function(url, destfile) {
+  
+    mode <- "wb"
+  
+    # https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17715
+    fixup <-
+      Sys.info()[["sysname"]] == "Windows" &&
+      substring(url, 1L, 5L) == "file:"
+  
+    if (fixup)
+      mode <- "w+b"
+  
+    utils::download.file(
+      url      = url,
+      destfile = destfile,
+      mode     = mode,
+      quiet    = TRUE
+    )
+  
+  }
+  
+  renv_bootstrap_download_cran_latest <- function(version) {
+  
+    spec <- renv_bootstrap_download_cran_latest_find(version)
+  
+    message("* Downloading renv ", version, " ... ", appendLF = FALSE)
+  
+    type  <- spec$type
+    repos <- spec$repos
+  
+    info <- tryCatch(
+      utils::download.packages(
+        pkgs    = "renv",
+        destdir = tempdir(),
+        repos   = repos,
+        type    = type,
+        quiet   = TRUE
+      ),
+      condition = identity
+    )
+  
+    if (inherits(info, "condition")) {
+      message("FAILED")
+      return(FALSE)
+    }
+  
+    # report success and return
+    message("OK (downloaded ", type, ")")
+    info[1, 2]
+  
+  }
+  
+  renv_bootstrap_download_cran_latest_find <- function(version) {
+  
+    # check whether binaries are supported on this system
+    binary <-
+      getOption("renv.bootstrap.binary", default = TRUE) &&
+      !identical(.Platform$pkgType, "source") &&
+      !identical(getOption("pkgType"), "source") &&
+      Sys.info()[["sysname"]] %in% c("Darwin", "Windows")
+  
+    types <- c(if (binary) "binary", "source")
+  
+    # iterate over types + repositories
+    for (type in types) {
+      for (repos in renv_bootstrap_repos()) {
+  
+        # retrieve package database
+        db <- tryCatch(
+          as.data.frame(
+            utils::available.packages(type = type, repos = repos),
+            stringsAsFactors = FALSE
+          ),
+          error = identity
+        )
+  
+        if (inherits(db, "error"))
+          next
+  
+        # check for compatible entry
+        entry <- db[db$Package %in% "renv" & db$Version %in% version, ]
+        if (nrow(entry) == 0)
+          next
+  
+        # found it; return spec to caller
+        spec <- list(entry = entry, type = type, repos = repos)
+        return(spec)
+  
+      }
+    }
+  
+    # if we got here, we failed to find renv
+    fmt <- "renv %s is not available from your declared package repositories"
+    stop(sprintf(fmt, version))
+  
+  }
+  
+  renv_bootstrap_download_cran_archive <- function(version) {
+  
+    name <- sprintf("renv_%s.tar.gz", version)
+    repos <- renv_bootstrap_repos()
+    urls <- file.path(repos, "src/contrib/Archive/renv", name)
+    destfile <- file.path(tempdir(), name)
+  
+    message("* Downloading renv ", version, " ... ", appendLF = FALSE)
+  
+    for (url in urls) {
+  
+      status <- tryCatch(
+        renv_bootstrap_download_impl(url, destfile),
+        condition = identity
+      )
+  
+      if (identical(status, 0L)) {
+        message("OK")
+        return(destfile)
+      }
+  
+    }
+  
+    message("FAILED")
+    return(FALSE)
+  
+  }
+  
+  renv_bootstrap_download_github <- function(version) {
+  
+    enabled <- Sys.getenv("RENV_BOOTSTRAP_FROM_GITHUB", unset = "TRUE")
+    if (!identical(enabled, "TRUE"))
+      return(FALSE)
+  
+    # prepare download options
+    pat <- Sys.getenv("GITHUB_PAT")
+    if (nzchar(Sys.which("curl")) && nzchar(pat)) {
+      fmt <- "--location --fail --header \"Authorization: token %s\""
+      extra <- sprintf(fmt, pat)
+      saved <- options("download.file.method", "download.file.extra")
+      options(download.file.method = "curl", download.file.extra = extra)
+      on.exit(do.call(base::options, saved), add = TRUE)
+    } else if (nzchar(Sys.which("wget")) && nzchar(pat)) {
+      fmt <- "--header=\"Authorization: token %s\""
+      extra <- sprintf(fmt, pat)
+      saved <- options("download.file.method", "download.file.extra")
+      options(download.file.method = "wget", download.file.extra = extra)
+      on.exit(do.call(base::options, saved), add = TRUE)
+    }
+  
+    message("* Downloading renv ", version, " from GitHub ... ", appendLF = FALSE)
+  
+    url <- file.path("https://api.github.com/repos/rstudio/renv/tarball", version)
+    name <- sprintf("renv_%s.tar.gz", version)
+    destfile <- file.path(tempdir(), name)
+  
+    status <- tryCatch(
+      renv_bootstrap_download_impl(url, destfile),
+      condition = identity
+    )
+  
+    if (!identical(status, 0L)) {
+      message("FAILED")
+      return(FALSE)
+    }
+  
+    message("OK")
+    return(destfile)
+  
+  }
+  
+  renv_bootstrap_install <- function(version, tarball, library) {
+  
+    # attempt to install it into project library
+    message("* Installing renv ", version, " ... ", appendLF = FALSE)
+    dir.create(library, showWarnings = FALSE, recursive = TRUE)
+  
+    # invoke using system2 so we can capture and report output
+    bin <- R.home("bin")
+    exe <- if (Sys.info()[["sysname"]] == "Windows") "R.exe" else "R"
+    r <- file.path(bin, exe)
+    args <- c("--vanilla", "CMD", "INSTALL", "-l", shQuote(library), shQuote(tarball))
+    output <- system2(r, args, stdout = TRUE, stderr = TRUE)
+    message("Done!")
+  
+    # check for successful install
+    status <- attr(output, "status")
+    if (is.numeric(status) && !identical(status, 0L)) {
+      header <- "Error installing renv:"
+      lines <- paste(rep.int("=", nchar(header)), collapse = "")
+      text <- c(header, lines, output)
+      writeLines(text, con = stderr())
+    }
+  
+    status
+  
+  }
+  
+  renv_bootstrap_platform_prefix <- function() {
+  
+    # construct version prefix
+    version <- paste(R.version$major, R.version$minor, sep = ".")
+    prefix <- paste("R", numeric_version(version)[1, 1:2], sep = "-")
+  
+    # include SVN revision for development versions of R
+    # (to avoid sharing platform-specific artefacts with released versions of R)
+    devel <-
+      identical(R.version[["status"]],   "Under development (unstable)") ||
+      identical(R.version[["nickname"]], "Unsuffered Consequences")
+  
+    if (devel)
+      prefix <- paste(prefix, R.version[["svn rev"]], sep = "-r")
+  
+    # build list of path components
+    components <- c(prefix, R.version$platform)
+  
+    # include prefix if provided by user
+    prefix <- renv_bootstrap_platform_prefix_impl()
+    if (!is.na(prefix) && nzchar(prefix))
+      components <- c(prefix, components)
+  
+    # build prefix
+    paste(components, collapse = "/")
+  
+  }
+  
+  renv_bootstrap_platform_prefix_impl <- function() {
+  
+    # if an explicit prefix has been supplied, use it
+    prefix <- Sys.getenv("RENV_PATHS_PREFIX", unset = NA)
+    if (!is.na(prefix))
+      return(prefix)
+  
+    # if the user has requested an automatic prefix, generate it
+    auto <- Sys.getenv("RENV_PATHS_PREFIX_AUTO", unset = NA)
+    if (auto %in% c("TRUE", "True", "true", "1"))
+      return(renv_bootstrap_platform_prefix_auto())
+  
+    # empty string on failure
+    ""
+  
+  }
+  
+  renv_bootstrap_platform_prefix_auto <- function() {
+  
+    prefix <- tryCatch(renv_bootstrap_platform_os(), error = identity)
+    if (inherits(prefix, "error") || prefix %in% "unknown") {
+  
+      msg <- paste(
+        "failed to infer current operating system",
+        "please file a bug report at https://github.com/rstudio/renv/issues",
+        sep = "; "
+      )
+  
+      warning(msg)
+  
+    }
+  
+    prefix
+  
+  }
+  
+  renv_bootstrap_platform_os <- function() {
+  
+    sysinfo <- Sys.info()
+    sysname <- sysinfo[["sysname"]]
+  
+    # handle Windows + macOS up front
+    if (sysname == "Windows")
+      return("windows")
+    else if (sysname == "Darwin")
+      return("macos")
+  
+    # check for os-release files
+    for (file in c("/etc/os-release", "/usr/lib/os-release"))
+      if (file.exists(file))
+        return(renv_bootstrap_platform_os_via_os_release(file, sysinfo))
+  
+    # check for redhat-release files
+    if (file.exists("/etc/redhat-release"))
+      return(renv_bootstrap_platform_os_via_redhat_release())
+  
+    "unknown"
+  
+  }
+  
+  renv_bootstrap_platform_os_via_os_release <- function(file, sysinfo) {
+  
+    # read /etc/os-release
+    release <- utils::read.table(
+      file             = file,
+      sep              = "=",
+      quote            = c("\"", "'"),
+      col.names        = c("Key", "Value"),
+      comment.char     = "#",
+      stringsAsFactors = FALSE
+    )
+  
+    vars <- as.list(release$Value)
+    names(vars) <- release$Key
+  
+    # get os name
+    os <- tolower(sysinfo[["sysname"]])
+  
+    # read id
+    id <- "unknown"
+    for (field in c("ID", "ID_LIKE")) {
+      if (field %in% names(vars) && nzchar(vars[[field]])) {
+        id <- vars[[field]]
+        break
+      }
+    }
+  
+    # read version
+    version <- "unknown"
+    for (field in c("UBUNTU_CODENAME", "VERSION_CODENAME", "VERSION_ID", "BUILD_ID")) {
+      if (field %in% names(vars) && nzchar(vars[[field]])) {
+        version <- vars[[field]]
+        break
+      }
+    }
+  
+    # join together
+    paste(c(os, id, version), collapse = "-")
+  
+  }
+  
+  renv_bootstrap_platform_os_via_redhat_release <- function() {
+  
+    # read /etc/redhat-release
+    contents <- readLines("/etc/redhat-release", warn = FALSE)
+  
+    # infer id
+    id <- if (grepl("centos", contents, ignore.case = TRUE))
+      "centos"
+    else if (grepl("redhat", contents, ignore.case = TRUE))
+      "redhat"
+    else
+      "unknown"
+  
+    # try to find a version component (very hacky)
+    version <- "unknown"
+  
+    parts <- strsplit(contents, "[[:space:]]")[[1L]]
+    for (part in parts) {
+  
+      nv <- tryCatch(numeric_version(part), error = identity)
+      if (inherits(nv, "error"))
+        next
+  
+      version <- nv[1, 1]
+      break
+  
+    }
+  
+    paste(c("linux", id, version), collapse = "-")
+  
+  }
+  
+  renv_bootstrap_library_root_name <- function(project) {
+  
+    # use project name as-is if requested
+    asis <- Sys.getenv("RENV_PATHS_LIBRARY_ROOT_ASIS", unset = "FALSE")
+    if (asis)
+      return(basename(project))
+  
+    # otherwise, disambiguate based on project's path
+    id <- substring(renv_bootstrap_hash_text(project), 1L, 8L)
+    paste(basename(project), id, sep = "-")
+  
+  }
+  
+  renv_bootstrap_library_root <- function(project) {
+  
+    path <- Sys.getenv("RENV_PATHS_LIBRARY", unset = NA)
+    if (!is.na(path))
+      return(path)
+  
+    path <- Sys.getenv("RENV_PATHS_LIBRARY_ROOT", unset = NA)
+    if (!is.na(path)) {
+      name <- renv_bootstrap_library_root_name(project)
+      return(file.path(path, name))
+    }
+  
+    prefix <- renv_bootstrap_profile_prefix()
+    paste(c(project, prefix, "renv/library"), collapse = "/")
+  
+  }
+  
+  renv_bootstrap_validate_version <- function(version) {
+  
+    loadedversion <- utils::packageDescription("renv", fields = "Version")
+    if (version == loadedversion)
+      return(TRUE)
+  
+    # assume four-component versions are from GitHub; three-component
+    # versions are from CRAN
+    components <- strsplit(loadedversion, "[.-]")[[1]]
+    remote <- if (length(components) == 4L)
+      paste("rstudio/renv", loadedversion, sep = "@")
+    else
+      paste("renv", loadedversion, sep = "@")
+  
+    fmt <- paste(
+      "renv %1$s was loaded from project library, but this project is configured to use renv %2$s.",
+      "Use `renv::record(\"%3$s\")` to record renv %1$s in the lockfile.",
+      "Use `renv::restore(packages = \"renv\")` to install renv %2$s into the project library.",
+      sep = "\n"
+    )
+  
+    msg <- sprintf(fmt, loadedversion, version, remote)
+    warning(msg, call. = FALSE)
+  
+    FALSE
+  
+  }
+  
+  renv_bootstrap_hash_text <- function(text) {
+  
+    hashfile <- tempfile("renv-hash-")
+    on.exit(unlink(hashfile), add = TRUE)
+  
+    writeLines(text, con = hashfile)
+    tools::md5sum(hashfile)
+  
+  }
+  
+  renv_bootstrap_load <- function(project, libpath, version) {
+  
+    # try to load renv from the project library
+    if (!requireNamespace("renv", lib.loc = libpath, quietly = TRUE))
+      return(FALSE)
+  
+    # warn if the version of renv loaded does not match
+    renv_bootstrap_validate_version(version)
+  
+    # load the project
+    renv::load(project)
+  
+    TRUE
+  
+  }
+  
+  renv_bootstrap_profile_load <- function(project) {
+  
+    # if RENV_PROFILE is already set, just use that
+    profile <- Sys.getenv("RENV_PROFILE", unset = NA)
+    if (!is.na(profile) && nzchar(profile))
+      return(profile)
+  
+    # check for a profile file (nothing to do if it doesn't exist)
+    path <- file.path(project, "renv/local/profile")
+    if (!file.exists(path))
+      return(NULL)
+  
+    # read the profile, and set it if it exists
+    contents <- readLines(path, warn = FALSE)
+    if (length(contents) == 0L)
+      return(NULL)
+  
+    # set RENV_PROFILE
+    profile <- contents[[1L]]
+    if (nzchar(profile))
+      Sys.setenv(RENV_PROFILE = profile)
+  
+    profile
+  
+  }
+  
+  renv_bootstrap_profile_prefix <- function() {
+    profile <- renv_bootstrap_profile_get()
+    if (!is.null(profile))
+      return(file.path("renv/profiles", profile))
+  }
+  
+  renv_bootstrap_profile_get <- function() {
+    profile <- Sys.getenv("RENV_PROFILE", unset = "")
+    renv_bootstrap_profile_normalize(profile)
+  }
+  
+  renv_bootstrap_profile_set <- function(profile) {
+    profile <- renv_bootstrap_profile_normalize(profile)
+    if (is.null(profile))
+      Sys.unsetenv("RENV_PROFILE")
+    else
+      Sys.setenv(RENV_PROFILE = profile)
+  }
+  
+  renv_bootstrap_profile_normalize <- function(profile) {
+  
+    if (is.null(profile) || profile %in% c("", "default"))
+      return(NULL)
+  
+    profile
+  
+  }
+
+  # load the renv profile, if any
+  renv_bootstrap_profile_load(project)
+
+  # construct path to library root
+  root <- renv_bootstrap_library_root(project)
+
+  # construct library prefix for platform
+  prefix <- renv_bootstrap_platform_prefix()
+
+  # construct full libpath
+  libpath <- file.path(root, prefix)
+
+  # attempt to load
+  if (renv_bootstrap_load(project, libpath, version))
+    return(TRUE)
+
+  # load failed; inform user we're about to bootstrap
+  prefix <- paste("# Bootstrapping renv", version)
+  postfix <- paste(rep.int("-", 77L - nchar(prefix)), collapse = "")
+  header <- paste(prefix, postfix)
+  message(header)
+
+  # perform bootstrap
+  bootstrap(version, libpath)
+
+  # exit early if we're just testing bootstrap
+  if (!is.na(Sys.getenv("RENV_BOOTSTRAP_INSTALL_ONLY", unset = NA)))
+    return(TRUE)
+
+  # try again to load
+  if (requireNamespace("renv", lib.loc = libpath, quietly = TRUE)) {
+    message("* Successfully installed and loaded renv ", version, ".")
+    return(renv::load())
+  }
+
+  # failed to download or load renv; warn the user
+  msg <- c(
+    "Failed to find an renv installation: the project will not be loaded.",
+    "Use `renv::activate()` to re-initialize the project."
+  )
+
+  warning(paste(msg, collapse = "\n"), call. = FALSE)
+
+})

--- a/src/update_shallowgroundwater/renv/settings.dcf
+++ b/src/update_shallowgroundwater/renv/settings.dcf
@@ -1,0 +1,8 @@
+external.libraries:
+ignored.packages:
+package.dependency.fields: Imports, Depends, LinkingTo
+r.version:
+snapshot.type: implicit
+use.cache: TRUE
+vcs.ignore.library: TRUE
+vcs.ignore.local: TRUE

--- a/src/update_shallowgroundwater/renv/settings.dcf
+++ b/src/update_shallowgroundwater/renv/settings.dcf
@@ -2,7 +2,7 @@ external.libraries:
 ignored.packages:
 package.dependency.fields: Imports, Depends, LinkingTo
 r.version:
-snapshot.type: implicit
+snapshot.type: all
 use.cache: TRUE
 vcs.ignore.library: TRUE
 vcs.ignore.local: TRUE

--- a/src/update_shallowgroundwater/update_shallowgroundwater.Rproj
+++ b/src/update_shallowgroundwater/update_shallowgroundwater.Rproj
@@ -1,0 +1,18 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: knitr
+LaTeX: XeLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
+BuildType: Website


### PR DESCRIPTION
This builds on findings in https://github.com/inbo/n2khab-mne-design/pull/74#issue-698959257: `shallowgroundwater` has now been updated.

All explanation can be found in the [compiled HTML file](https://github.com/inbo/n2khab-preprocessing/files/6946310/updating_shallowgroundwater.html.zip). Although validation results of this result are very good (new data source version, as gpkg, is available in [GDrive](https://drive.google.com/drive/folders/1W2ycD8S7CwoBV6pQLYXoOyUQ9xoIegv_)), i.e. only 1.4% of obliggwdep types missed (see evaluation update in https://github.com/inbo/n2khab-mne-design/pull/74#issuecomment-894343758), more work will be needed to make the result more **robust** in covering (almost) all areas with 'shallow groundwater'. This will happen most probably by dropping some of the additions made here and instead adding areas based on other (dunes) + changed (soil?) environmental criteria. See comments at the end of the 'check results' chapter.