### PR TITLE
Updating shallowgroundwater: partly alternative approach

### DIFF
--- a/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
+++ b/src/update_shallowgroundwater/10_update_shallowgroundwater.Rmd
@@ -16,34 +16,32 @@ Hence, the area it covers needs to be made broader.
 
 In this document, we append several layers to `shallowgroundwater`.
 The **aim** is to select areas which `shallowgroundwater` doesn't cover yet and where '(almost) everywhere groundwater dependent' types (here also called 'obliggwdep' types) are present.
-Such 'areas of interest' are e.g. anthropogenic soil type polygons, and a ring around the borders of `shallowgroundwater`.
+Such 'areas of interest' are e.g. anthropogenic soil type polygons.
 
-- In order not to exaggerate the extension of `shallowgroundwater`, we will subseqently limit those areas to _buffers (of `r params$buffer_obliggwdep` m) around habitatmap polygons with 'obliggwdep' types_ -- still subsequently clipping along the borders of the aforementioned areas.
-So in practice, we first select the habitatmap polygons with 'obliggwdep' types that intersect the areas of interest, we buffer them, and we clip the result along the areas of interest.
+- In the case of anthropogenic soil type polygons, we will subseqently limit those areas to _buffers (of `r params$buffer_obliggwdep` m) around habitatmap polygons with 'obliggwdep' types_ -- still subsequently clipping along the borders of the aforementioned areas.
+So in practice, we first select the habitatmap polygons with 'obliggwdep' types that intersect the anthropogenic soil type polygons, we buffer them, and we clip the result along the areas of interest.
   - The buffers around habitatmap polygons with 'obliggwdep' types are applied since it is expected that shallow groundwater (with potentially 'locally groundwater dependent' types) will occur in the vicinity of those polygons.
-- In a next step, we want to add a _buffer of 200 m_ around the resulting polygons.
+- In a next step, we want to add a _buffer of `r params$buffer_areas` m_ around the obtained polygons, and also around the original `shallowgroundwater` layer.
 This is done as a further means of conservative area selection: we rather need too much area than too little, for protection against over-restricting target populations.
 
 The areas of interest are:
 
-- all _anthropogenic soil type polygons_: i.e. where the `bsm_mo_soilunitype` column of the `soilmap_simple` data source starts with `"O"`;
-- a _ring around_ `shallowgroundwater` of 200 m wide.
+- all _anthropogenic soil type polygons_: i.e. where the `bsm_mo_soilunitype` column of the `soilmap_simple` data source starts with `"O"`.
 
 Regarding the anthropogenic soil type polygons, from earlier evaluation it appeared that the _narrow ones that contain 'obliggwdep' types_ are interesting as a whole.
 Hence we select them as a whole instead of selecting buffers around the habitatmap polygons with 'obliggwdep' types.
-And also in this case we end by finally adding a buffer of 200 m to these soil type polygons.
 
 - An appropriate algorithm had to be made that selects meaningful polygons - at first it resulted in complete cities meeting the narrowness requirement (since they are part of anthropogenic soil type polygons with long, narrow parts).
 - Hence an additional condition was required: a minimal amount of 'obliggwdep' type must be present in such polygons.
 
-Finally, we append the parts -- of all new layers -- that don't overlap `shallowgroundwater`, to `shallowgroundwater`.
-The resulting new version of `shallowgroundwater` is written here as **`sg_extended.gpkg`**.
+Finally, we stitch the parts.
+The resulting new version of `shallowgroundwater` is written here as **`sg_extended_2.gpkg`**.
 
-Hence we will have three separate sources, which we will document as three extra TRUE/FALSE column inside `sg_extended.gpkg`:
+Hence we will have three separate sources, which we will document as three extra TRUE/FALSE column inside `sg_extended_2.gpkg`:
 
 - `within_soilanthrop_plus_buffer`
 - `narrow_soilanthrop_plus_buffer`
-- `nearby_originalsg_plus_buffer`
+- `sg_plus_buffer`
 
 Where an area overlapped between several of these sources, more than one column is set as `TRUE`.
 
@@ -273,142 +271,7 @@ mapview(narrow_soilanthrop_with_obliggwdep,
 
 Resulting object: `narrow_soilanthrop_with_obliggwdep`.
 
-### Buffer `r params$buffer_obliggwdep` m around obliggwdep types, within a ring of 200 m around `shallowgroundwater`
-
-We will first create a ring around `shallowgroundwater` of 200 m width.
-
-```{r eval=!gpkg_sg_exists}
-sg_repairedgeom <- 
-  st_make_valid(sg) %>% 
-  st_cast("MULTIPOLYGON")
-write_sf(sg_repairedgeom,
-         file.path(datapath, 
-                   "sg_repairedgeom.gpkg"),
-         delete_dsn = TRUE)
-```
-
-```{r eval=gpkg_sg_exists, include=FALSE}
-sg_repairedgeom <- 
-  read_sf(file.path(datapath, 
-                    "sg_repairedgeom.gpkg"))
-```
-
-```{r include=FALSE}
-gpkg_sg_ring_exists <- 
-  file.exists(file.path(datapath, 
-                        "sg_ring.gpkg"))
-```
-
-```{r eval=!gpkg_sg_ring_exists}
-system.time({
-sg_union <-
-  sg_repairedgeom %>%
-  st_union()
-sg_buff <-
-  sg_union %>%
-  st_buffer(200)
-sg_ring <- 
-  st_difference(sg_buff, sg_union)
-})
-#     user   system  elapsed 
-# 2044.543    0.000 2045.678 
-write_sf(sg_ring, 
-         file.path(datapath, 
-                   "sg_ring.gpkg"),
-         delete_dsn = TRUE)
-```
-
-```{r eval=gpkg_sg_ring_exists, include=FALSE}
-sg_ring <- 
-  read_sf(file.path(datapath, 
-                    "sg_ring.gpkg"))
-```
-
-Then we create the buffered habitatmap polygons with 'obliggwdep' types within the ring.
-
-```{r eval=FALSE, echo=FALSE}
-# following step takes too much time! Interrupted this manually.
-system.time(
-buffered_obliggwdep_nearsg <-
-  hmt_pol_obliggwdep[sg_ring, ] %>% # especially this takes an age. Will use QGIS here.
-  st_make_valid(.) %>% 
-  st_buffer(params$buffer_obliggwdep) %>% 
-  st_union()
-)
-```
-
-```{r include=FALSE}
-gpkg_buffered_obliggwdep_within_sg_ring_exists <- 
-  file.exists(file.path(datapath, 
-                        "buffered_obliggwdep_within_sg_ring.gpkg"))
-```
-
-```{r eval=!gpkg_buffered_obliggwdep_within_sg_ring_exists || params$rewrite_intermediate_files}
-# qgis_algorithms() %>% filter(str_detect(algorithm, "extract"))
-# qgis_show_help("native:extractbylocation")
-hmt_pol_obliggwdep %>% 
-  st_make_valid %>% 
-  write_sf(file.path(datapath, 
-                     "hmt_pol_obliggwdep.gpkg"),
-           delete_dsn = TRUE)
-```
-
-
-```{r}
-plan(multisession) # future kept here as demonstration
-```
-
-
-```{r eval=!gpkg_buffered_obliggwdep_within_sg_ring_exists || params$rewrite_intermediate_files, warning=FALSE}
-# use of future unneeded in this case (runs quickly; however
-# hmt_pol_obliggwdep[sg_ring, ] takes very long)
-f <- future({
-  qgis_run_algorithm("native:extractbylocation",
-                       INPUT = file.path(datapath, 
-                                         "hmt_pol_obliggwdep.gpkg"),
-                       PREDICATE = 0,
-                       INTERSECT = file.path(datapath, 
-                                             "sg_ring.gpkg"))
-}, seed = NULL)
-# resolved(f)
-obliggwdep_sgring_qgis <- value(f, stdout = FALSE) # blocks calling R session if !resolved(f)
-```
-
-
-```{r eval=!gpkg_buffered_obliggwdep_within_sg_ring_exists || params$rewrite_intermediate_files, warning=FALSE}
-# use of future unneeded in this case (runs quickly)
-f <- future({
-  elapsed <- 
-    system.time(
-      result <-
-        obliggwdep_sgring_qgis$OUTPUT %>% 
-        read_sf %>% 
-        st_buffer(params$buffer_obliggwdep) %>% 
-        st_union() %>% 
-        st_intersection(sg_ring)
-    )
-  list(result = result, elapsed = elapsed)
-}, seed = NULL)
-# resolved(f)
-value(f, stdout = FALSE)$elapsed
-buffered_obliggwdep_within_sg_ring <- value(f, stdout = FALSE)$result
-write_sf(buffered_obliggwdep_within_sg_ring, 
-         file.path(datapath, 
-                   "buffered_obliggwdep_within_sg_ring.gpkg"),
-         delete_dsn = TRUE)
-```
-
-
-```{r eval=gpkg_buffered_obliggwdep_within_sg_ring_exists && !params$rewrite_intermediate_files, include=FALSE}
-buffered_obliggwdep_within_sg_ring <- 
-  read_sf(file.path(datapath, 
-                    "buffered_obliggwdep_within_sg_ring.gpkg"))
-```
-
-Resulting object: `buffered_obliggwdep_within_sg_ring`.
-
-
-## Add 200 m buffer around previously created zones to minimize false negatives
+## Add `r params$buffer_areas` m buffer to minimize false negatives
 
 ```{r include=FALSE}
 gpkg_newareas_exists <- 
@@ -416,33 +279,49 @@ gpkg_newareas_exists <-
                         "new_areas.gpkg"))
 ```
 
+```{r}
+plan(multisession) # future kept here as demonstration
+```
+
 ```{r eval=!gpkg_newareas_exists || params$rewrite_intermediate_files}
-buffered_obliggwdep_within_soilanthrop_buff200 <- 
+buffered_obliggwdep_within_soilanthrop_buff <- 
   buffered_obliggwdep_within_soilanthrop %>% 
-  st_buffer(200) %>% 
+  st_buffer(params$buffer_areas) %>% 
   st_union %>% 
   st_as_sf
 
-narrow_soilanthrop_with_obliggwdep_buff200 <-
+narrow_soilanthrop_with_obliggwdep_buff <-
   narrow_soilanthrop_with_obliggwdep %>% 
   select(-everything()) %>% 
-  st_buffer(200) %>% 
+  st_buffer(params$buffer_areas) %>% 
   st_union %>% 
   st_as_sf
 
-buffered_obliggwdep_within_sg_ring_buff200 <- 
-  buffered_obliggwdep_within_sg_ring %>% 
-  st_buffer(200) %>% 
-  st_as_sf
+f <- future({
+  elapsed <- 
+    system.time(
+      result <-
+        sg_repairedgeom %>% 
+        st_union %>% 
+        st_buffer(params$buffer_areas) %>% 
+        st_as_sf
+    )
+  list(result = result, elapsed = elapsed)
+}, seed = NULL)
+# resolved(f)
+# value(f, stdout = FALSE)$elapsed
+#    user  system elapsed 
+# 876.952   1.416 879.065
+sg_buff <- value(f, stdout = FALSE)$result
 
 if (gpkg_newareas_exists) unlink(file.path(datapath, "new_areas.gpkg"))
 
-list(buffered_obliggwdep_within_soilanthrop_buff200 =
-       buffered_obliggwdep_within_soilanthrop_buff200,
-     narrow_soilanthrop_with_obliggwdep_buff200 =
-       narrow_soilanthrop_with_obliggwdep_buff200,
-     buffered_obliggwdep_within_sg_ring_buff200 =
-       buffered_obliggwdep_within_sg_ring_buff200) %>% 
+list(buffered_obliggwdep_within_soilanthrop_buff =
+       buffered_obliggwdep_within_soilanthrop_buff,
+     narrow_soilanthrop_with_obliggwdep_buff =
+       narrow_soilanthrop_with_obliggwdep_buff,
+     sg_buff =
+       sg_buff) %>% 
   walk2(names(.),
         ~write_sf(.x,
                   dsn = file.path(datapath, "new_areas.gpkg"),
@@ -469,14 +348,13 @@ Each layer consists of just one Multipolygon.
 That is the result of unioning steps (obtained with `st_union()`; corresponding QGIS terminology is `native:aggregate`).
 The unioning is done in order to prevent overlapping polygons within the same layer as a consequence of creating buffers.
 
-## Union the new zones (keeping intersections), subtract the original `shallowgroundwater` layer and append
+## Union the new zones (keeping intersections)
 
 We extend `shallowgroundwater` as described in section \@ref(method).
 
 ```{r include=FALSE}
-gpkg_sg_extended_exists <- file.exists(file.path(datapath, "sg_extended.gpkg"))
+gpkg_sg_extended_exists <- file.exists(file.path(datapath, "sg_extended_2.gpkg"))
 ```
-
 
 ```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists, warning=FALSE}
 # qgis_arguments("native:union")
@@ -486,10 +364,10 @@ f <- future({
     system.time(
       result <- qgis_run_algorithm("native:union",
                                    INPUT = 
-                                     buffered_obliggwdep_within_soilanthrop_buff200 %>% 
+                                     buffered_obliggwdep_within_soilanthrop_buff %>% 
                                      mutate(within_soilanthrop_plus_buffer = TRUE),
                                    OVERLAY = 
-                                     narrow_soilanthrop_with_obliggwdep_buff200 %>% 
+                                     narrow_soilanthrop_with_obliggwdep_buff %>% 
                                      mutate(narrow_soilanthrop_plus_buffer = TRUE))
     )
   list(result = result, elapsed = elapsed)
@@ -505,8 +383,8 @@ f <- future({
                                    INPUT = 
                                      res_filepath,
                                    OVERLAY = 
-                                     buffered_obliggwdep_within_sg_ring_buff200 %>% 
-                                     mutate(nearby_originalsg_plus_buffer = TRUE))
+                                     sg_buff %>% 
+                                     mutate(sg_plus_buffer = TRUE))
     )
   list(result = result, elapsed = elapsed)
 }, seed = NULL)
@@ -515,46 +393,22 @@ value(f, stdout = FALSE, signal = FALSE)$elapsed
 res_filepath2 <- value(f, stdout = FALSE)$result$OUTPUT %>% as.character
 ```
 
-```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists, warning=FALSE}
-f <- future({
-  elapsed <- 
-    system.time(
-      result <- 
-        read_sf(res_filepath2) %>% 
-        select(-starts_with("fid")) %>% 
-        mutate(across(where(is.logical), ~ifelse(is.na(.), FALSE, .))) %>% 
-        st_difference(
-          sg_repairedgeom %>% 
-            st_union()
-        )
-    )
-  list(result = result, elapsed = elapsed)
-}, seed = NULL)
-# resolved(f)
-value(f, stdout = FALSE, signal = FALSE)$elapsed
-addition <- value(f, stdout = FALSE)$result
-```
-
-The result is written as `sg_extended.gpkg`.
+The result is written as `sg_extended_2.gpkg`.
 
 ```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists}
 sg_extended <- 
-  sg_repairedgeom %>% 
-  as_tibble %>% 
-  bind_rows(
-    addition %>% as_tibble
-  ) %>% 
-  st_sf(crs = 31370)
+  read_sf(res_filepath2) %>% 
+  select(-starts_with("fid")) %>% 
+  mutate(across(where(is.logical), ~ifelse(is.na(.), FALSE, .)))
 ```
-
-Note that the attributes of the original data source need cleaning; `sg_extended` now has `r ncol(sg_extended) - 1` attribute columns.
 
 ```{r eval=params$overwrite_sg_extended || !gpkg_sg_extended_exists}
 system.time(
-write_sf(sg_extended,
-         file.path(datapath, "sg_extended.gpkg"),
+st_write(sg_extended,
+         file.path(datapath, "sg_extended_2.gpkg"),
+         layer = "sg_extended",
          delete_dsn = TRUE,
-         )
+         quiet = TRUE)
 )
 ```
 

--- a/src/update_shallowgroundwater/20_check_result.Rmd
+++ b/src/update_shallowgroundwater/20_check_result.Rmd
@@ -1,7 +1,7 @@
 # Check results
 
 ```{r}
-filepath <- file.path(datapath, "sg_extended.gpkg")
+filepath <- file.path(datapath, "sg_extended_2.gpkg")
 ```
 
 - Checksums:
@@ -29,7 +29,7 @@ glimpse(pol)
 - Sensible results?
 
 ```{r include=FALSE}
-image <- file.path(local_root, "images/qgis_shot.png")
+image <- file.path(local_root, "images/qgis_shot_sg_extended_2.png")
 image_exists <- file.exists(image)
 ```
 
@@ -38,8 +38,4 @@ image_exists <- file.exists(image)
 include_graphics(image)
 ```
 
-The pattern of locally buffered 'obliggwdep' types is quite dominant in the resulting layer.
-In contrast, the original layer has numerous narrow and small patches of shallow groundwater.
-So these may be too narrow.
-It might be sensible to also add a narrow buffer, e.g. 50 m, around the whole of the original layer.
-Or, obtaining a broader area by being more liberal in the selection of soil types.
+This looks better than in a previous trial (`sg_extended.gpkg`: <https://github.com/inbo/n2khab-preprocessing/pull/61>).

--- a/src/update_shallowgroundwater/index.Rmd
+++ b/src/update_shallowgroundwater/index.Rmd
@@ -15,6 +15,7 @@ params:
   rewrite_intermediate_files: TRUE
   overwrite_sg_extended: TRUE
   buffer_obliggwdep: 100
+  buffer_areas: 50
 output:
   bookdown::html_document2:
     code_folding: hide
@@ -48,7 +49,7 @@ library(future)
 
 # ISO8601 timestamp to set as fixed value in the GeoPackage 
 # (to be UPDATED to the actual creation date; at least update for each version):
-Sys.setenv(OGR_CURRENT_DATE = "2021-08-05T00:00:00.000Z")
+Sys.setenv(OGR_CURRENT_DATE = "2021-08-09T00:00:00.000Z")
 # This is used to keep results reproducible, as the timestamp is otherwise
 # updated each time.
 # Above environment variable OGR_CURRENT_DATE is used by the GDAL driver.


### PR DESCRIPTION
This PR adds to PR #61 and partly takes another approach. A file `sg_extended_2.gpkg` is written by the code.

[Link to updated compiled HTML file](https://github.com/inbo/n2khab-preprocessing/files/6955878/updating_shallowgroundwater__sg_extended_2.html.zip). New data source version, as gpkg, is available in [GDrive](https://drive.google.com/drive/folders/1W2ycD8S7CwoBV6pQLYXoOyUQ9xoIegv_).

Compared to `sg_extended.gpkg` (#61), several measures were taken to reduce the
influence of obliggwdep types on the result, notably by using a 50 m
instead of a 200 m buffer, and not using the obliggwdep polygons in the
ring. Instead of the latter, a 50 m buffer has been added and retained around
the original shallowgroundwater. So apart from that, only the (obliggwdep
bufferpolygons in) anthropogenic soil type polygons were added, with a buffer
of 50 m.

This resulted in a more natural spatial pattern, while the evaluation (in https://github.com/inbo/n2khab-mne-design/pull/74) still results in a 95% match with obliggwdep types. The 'piezometer evaluation' gives a 90% match. (sg_extended had 98.6% resp. 92% match, but its content were driven more by circular reasoning in obtaining a good evaluation). Especially dune types, 4010, 91E0_va/91E0_vn and 1310/1320/1330 will gain from further attention to improve `shallowgroundwater`.