### PR TITLE
README: replace master branch by 'main'

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,15 +79,15 @@ A tibble is a dataframe that makes working in the tidyverse a little [easier](ht
 More detailed info on git workflows at INBO: <https://inbo.github.io/tutorials/tags/git/>.
 See also [these git workshop materials](https://inbo.github.io/git-course/index.html).
 
-1. Make commits (in your local clone of the remote repo on Github) _in your own git branch_, branched off from the `master` branch.
+1. Make commits (in your local clone of the remote repo on Github) _in your own git branch_, branched off from the `main` branch.
 (But see this in a relative manner: exactly the same process can be repeated by someone else in turn, relative to your branch.
-So '`master`' in this protocol can be replaced by another branch name!)
+So '`main`' in this protocol can be replaced by another branch name!)
 You can push your branch to the remote as often as you like, as it will not influence other branches (first time: do `git push -u origin yourbranchname`; afterwards `git push` suffices). It serves as a backup and enables others to work with you on that branch.
-1. Meanwhile, make sure that your branch stays up to date with evolutions in `master` (i.e. in your local repo, update `master` with `git checkout master && git pull` and then, with your own branch checked out again, do `git merge --no-ff master`), in order to prevent merge conflicts with `master` later on.
+1. Meanwhile, make sure that your branch stays up to date with evolutions in `main` (i.e. in your local repo, update `main` with `git checkout main && git pull` and then, with your own branch checked out again, do `git merge --no-ff main`), in order to prevent merge conflicts with `main` later on.
 At this stage, you need to resolve any merge conflicts that may arise in your own branch.
-1. Propose to merge your commits into `master`: this starts with making a 'pull request' (PR; actually this is a merge request) and assign at least one reviewer before a merge can be decided. At that moment, open online discussion in the repo is possible on your changes (for other open discussion that you want to start, make an _issue_). As long as no merge is performed, more commits can be added to this PR with `git push`, e.g. to implement requested changes by others.
-    - note that, if you branched off another (reference) branch than `master`, make sure to change the reference branch in the pull request (the default reference is `master`).
-1. After your PR is merged, pull the reference branch (usually `master`) and clean up your local repo in order to keep up with the remote.
+1. Propose to merge your commits into `main`: this starts with making a 'pull request' (PR; actually this is a merge request) and assign at least one reviewer before a merge can be decided. At that moment, open online discussion in the repo is possible on your changes (for other open discussion that you want to start, make an _issue_). As long as no merge is performed, more commits can be added to this PR with `git push`, e.g. to implement requested changes by others.
+    - note that, if you branched off another (reference) branch than `main`, make sure to change the reference branch in the pull request (the default reference is `main`).
+1. After your PR is merged, pull the reference branch (usually `main`) and clean up your local repo in order to keep up with the remote.
 
 
 


### PR DESCRIPTION
Good to know: the base branch of the repo has now become `main`.

Contributors to this repo can run following git commands in a shell environment to implement the master-to-main migration locally:

```bash
git fetch --prune
git checkout master
git branch -m main
git branch -u origin/main # supposing origin is the name in use
git pull # makes main up to date with remote
```