### PR TITLE
Update watersurfaces 2024 and watersurfaces_hab v6

### DIFF
--- a/src/generate_watersurfaces_hab/10_generate_watersurfaces_hab.Rmd
+++ b/src/generate_watersurfaces_hab/10_generate_watersurfaces_hab.Rmd
@@ -8,7 +8,7 @@ We will create a map with watersurfaces that contain aquatic habitat and rib. Th
 
 * The water surfaces map of Flanders `watersurfaces`
 
-To be sure we will use the correct version of the data sources (version 2023 for the processed habitatmap and version 1.2 for watersurfaces), we will first derive the md5 file hashes and compare them to the file hashes in the [data source version overview table](https://docs.google.com/spreadsheets/d/1E8ERlfYwP3OjluL8d7_4rR1W34ka4LRCE35JTxf3WMI/edit#gid=2100595853)
+To be sure we will use the correct version of the data sources (version 2023 for the processed habitatmap and version 2024 for watersurfaces), we will first derive the md5 file hashes and compare them to the file hashes in the [data source version overview table](https://docs.google.com/spreadsheets/d/1E8ERlfYwP3OjluL8d7_4rR1W34ka4LRCE35JTxf3WMI/edit#gid=2100595853)
 
 ### Processed habitatmap
 
@@ -29,7 +29,7 @@ hashes <-
            md5 = map(filepath, function(x) {
                            x %>% md5sum() %>% str_c(collapse = '')
                          }) %>% as.character) %>% 
-           mutate(md5_ref = c("5e9a0cb2a53f88001796bd7457a343ac"),
+           mutate(md5_ref = c("5e9a0cb2a53f88001796bd7457a343ac"), # version 2023_v1
            match = md5 == md5_ref) %>%
     select(filename,
            md5,
@@ -70,7 +70,7 @@ hashes <-
            md5 = map(filepath, function(x) {
                            x %>% md5sum() %>% str_c(collapse = '')
                          }) %>% as.character) %>% 
-           mutate(md5_ref = c("72f6575ae7095622cd92eb2be720c7cb"), # version 1.2
+           mutate(md5_ref = c("d862df5b5e9ee8a2de4c333a7dcd7645"), # version 2024
            match = md5 == md5_ref) %>%
     select(filename,
            md5,
@@ -84,7 +84,7 @@ if (!all.equal(hashes$md5, hashes$md5_ref)) {
     stop(cat("The source map is NOT up to date ! Please check the datasource. "))
 }
 
-
+devtools::load_all("../../../n2khab") # n2khab not updated yet, I load my dev version
 # load watersurfaces with corrected geometry 
 # (argument fix_geom available since n2khab 0.9.0) 
 watersurfaces <- read_watersurfaces(fix_geom = TRUE)

--- a/src/generate_watersurfaces_hab/10_generate_watersurfaces_hab.Rmd
+++ b/src/generate_watersurfaces_hab/10_generate_watersurfaces_hab.Rmd
@@ -84,7 +84,10 @@ if (!all.equal(hashes$md5, hashes$md5_ref)) {
     stop(cat("The source map is NOT up to date ! Please check the datasource. "))
 }
 
-devtools::load_all("../../../n2khab") # n2khab not updated yet, I load my dev version
+# Official n2khab not updated yet, I work with an updated dev version installed with
+# remotes::install_github(repo="inbo/n2khab", ref = "bd784a5") #0.11.0.9000
+# and included in renv
+
 # load watersurfaces with corrected geometry 
 # (argument fix_geom available since n2khab 0.9.0) 
 watersurfaces <- read_watersurfaces(fix_geom = TRUE)

--- a/src/generate_watersurfaces_hab/20_check_result.Rmd
+++ b/src/generate_watersurfaces_hab/20_check_result.Rmd
@@ -66,19 +66,19 @@ sum(!validities | is.na(validities)) == 0
 
 ## Compare with the previous version 
 
-We load the previous version of watersurfaces_hab (version 4 based on watersurfaces_v1.1 and habitatmap_stdized_2020_v1)
+We load the previous version of watersurfaces_hab (version 5 based on watersurfaces_v1.2 and habitatmap_stdized_2023_v1)
 
 ```{r paged.print=FALSE, warning=FALSE}
 
-filepath_v4 <- file.path(path,"20_processed/_versions/watersurfaces_hab/watersurfaces_hab_v4/watersurfaces_hab.gpkg")
+filepath_v5 <- file.path(path,"20_processed/_versions/watersurfaces_hab/watersurfaces_hab_v5/watersurfaces_hab.gpkg")
 
 hashes <-
-    tibble(filepath_v4) %>%
-    mutate(filename = basename(filepath_v4),
-           md5 = map(filepath_v4, function(x) {
+    tibble(filepath_v5) %>%
+    mutate(filename = basename(filepath_v5),
+           md5 = map(filepath_v5, function(x) {
                            x %>% md5sum() %>% str_c(collapse = '')
                          }) %>% as.character) %>% 
-           mutate(md5_ref = c("96b6a7abc3d637d71052900970e70904"),
+           mutate(md5_ref = c("e7d9930938f5111de33de6ecaec31a66"),
            match = md5 == md5_ref) %>%
     select(filename,
            md5,
@@ -86,39 +86,39 @@ hashes <-
            match)
 
 if (!all.equal(hashes$md5, hashes$md5_ref)) {
-    stop(cat("The source map is NOT v4 ! Please check the datasource. "))
+    stop(cat("The source map is NOT v5 ! Please check the datasource. "))
 }
   
-(pol_v4 <- read_sf(filepath_v4, 
+(pol_v5 <- read_sf(filepath_v5, 
                 layer = "watersurfaces_hab_polygons"))
-(types_v4 <- read_sf(filepath_v4, 
+(types_v5 <- read_sf(filepath_v5, 
                 layer = "watersurfaces_hab_types"))
 ```
 
-- Are there differences between version v4 and version v5 and where are they located?
+- Are there differences between version v5 and version v6 and where are they located?
 
 In the table below we check the differences between both versions.
 Note that for a large number of records only polygon_habitatmap_id changes, but the geometry and the type description remain the same.
 
 ```{r}
-# polygons with polygon_id in v5 but not in version v4
-check_polygon_id_v5_v4 <- pol %>%
-  anti_join(pol_v4 %>%
+# polygons with polygon_id in v6 but not in version v5
+check_polygon_id_v6_v5 <- pol %>%
+  anti_join(pol_v5 %>%
               st_drop_geometry(), 
             by = c("polygon_id_habitatmap", "polygon_id_ws")) %>%
-  left_join(pol_v4 %>%
-              mutate(geom_text_v4 = st_as_text(geom)) %>%
+  left_join(pol_v5 %>%
+              mutate(geom_text_v5 = st_as_text(geom)) %>%
               st_drop_geometry() %>%
-              select(polygon_id, description_orig_v4 = description_orig, geom_text_v4), 
+              select(polygon_id, description_orig_v5 = description_orig, geom_text_v5), 
             by = c("polygon_id")) %>%
-  mutate(new_polygon_id = !(polygon_id %in% pol_v4$polygon_id),
-         new_polygon_id_ws = !(polygon_id_ws %in% pol_v4$polygon_id_ws),
-         new_polygon_id_habitatmap = !(polygon_id_habitatmap %in% pol_v4$polygon_id_habitatmap),
-         description_orig_update = description_orig != description_orig_v4,
-         geom_text_v5 = st_as_text(geom),  
-         geom_update = geom_text_v5 != geom_text_v4)
+  mutate(new_polygon_id = !(polygon_id %in% pol_v5$polygon_id),
+         new_polygon_id_ws = !(polygon_id_ws %in% pol_v5$polygon_id_ws),
+         new_polygon_id_habitatmap = !(polygon_id_habitatmap %in% pol_v5$polygon_id_habitatmap),
+         description_orig_update = description_orig != description_orig_v5,
+         geom_text_v6 = st_as_text(geom),  
+         geom_update = geom_text_v6 != geom_text_v5)
 
-check_polygon_id_v5_v4 %>%
+check_polygon_id_v6_v5 %>%
   st_drop_geometry() %>%
   group_by(new_polygon_id, new_polygon_id_ws, new_polygon_id_habitatmap, geom_update, description_orig_update) %>%
   summarise(n_records = n()) %>%
@@ -128,26 +128,28 @@ check_polygon_id_v5_v4 %>%
 
 ```
 
-We check some of the polygons for which the geometry has changed.
-Changes are minor.
+We check some of the polygons for which the geometry has changed. 
+
+In this case there are only 2 polygons with modified geometry
+Changes are minor for Stappersven, and bigger extent for Houtsaegerduinen.
 
 ```{r}
-check_geom <- check_polygon_id_v5_v4 %>%
+check_geom <- check_polygon_id_v6_v5 %>%
   filter(geom_update & !is.na(geom_update)) %>%
   slice_head(n = 5) %>%
   st_transform(4326)
 
-check_geom_v4 <- pol_v4 %>%
+check_geom_v5 <- pol_v5 %>%
   filter(polygon_id %in% check_geom$polygon_id) %>%
   st_transform(4326)
 
 check_geom %>%
   leaflet() %>%
   addTiles() %>%
-  addPolygons(group = "v5") %>%
-  addPolygons(data = check_geom_v4, color = "yellow", group = "v4") %>%
+  addPolygons(group = "v6") %>%
+  addPolygons(data = check_geom_v5, color = "red", group = "v5") %>%
    addLayersControl(
-   overlayGroups = c("v5", "v4"),
+   overlayGroups = c("v6 (blue)", "v5 (red)"),
     options = layersControlOptions(collapsed = FALSE)
   )
 ```
@@ -156,43 +158,43 @@ check_geom %>%
 
 
 ```{r}
-check_polygon_id_v4_v5 <- pol_v4 %>%
+check_polygon_id_v5_v6 <- pol_v5 %>%
   anti_join(pol %>%
               st_drop_geometry(), 
             by = c("polygon_id_habitatmap", "polygon_id_ws")) %>%
   mutate(ws_removed = !(polygon_id_ws %in% pol$polygon_id_ws))
 
-nrow(check_polygon_id_v4_v5) 
+nrow(check_polygon_id_v5_v6) 
 ```
 
 Here we show:
 
-+ new polygons from the watersurfaces layer that are included in `watersurfaces_hab_v5` (blue polygons)
-+ polygons from the watersurfaces layer that are removed in `watersurfaces_hab_v5` compared to `watersurfaces_hab_v4` (black polygons)
++ new polygons from the watersurfaces layer that are included in `watersurfaces_hab_v6` (blue polygons)
++ polygons from the watersurfaces layer that are removed in `watersurfaces_hab_v6` compared to `watersurfaces_hab_v5` (black polygons)
 
 
 ```{r}
 
-ws_new <- check_polygon_id_v5_v4 %>%
+ws_new <- check_polygon_id_v6_v5 %>%
   filter(new_polygon_id_ws) %>%
   st_transform(crs = 4326)
 
-ws_removed <- check_polygon_id_v4_v5 %>%
+ws_removed <- check_polygon_id_v5_v6 %>%
   filter(ws_removed) %>%
   st_transform(crs = 4326)
 
 leaflet() %>%
   addTiles(group = "OSM (default)") %>%
   addPolygons(data = ws_new, 
-            group = "in v5 and not v4 (blue)",
+            group = "in v6 and not v5 (blue)",
             popup = paste("polygon_id_habitatmap:", ws_new$polygon_id_habitatmap, "<br>",
                            "polygon_id_ws:", ws_new$polygon_id_ws)) %>%
   addPolygons(data = ws_removed, 
-            color = "black", group = "in v4 and not v5 (black)",
+            color = "black", group = "in v5 and not v6 (black)",
             popup = paste("polygon_id_habitatmap:", ws_removed$polygon_id_habitatmap, "<br>",
                            "polygon_id_ws:", ws_removed$polygon_id_ws)) %>% 
   addLayersControl(
-    overlayGroups = c("in v5 and not v4 (blue)", "in v4 and not v5 (black)"),
+    overlayGroups = c("in v6 and not v5 (blue)", "in v5 and not v6 (black)"),
     options = layersControlOptions(collapsed = FALSE)
   )
 ```

--- a/src/generate_watersurfaces_hab/20_check_result.Rmd
+++ b/src/generate_watersurfaces_hab/20_check_result.Rmd
@@ -1,8 +1,8 @@
 # Check results
 
-## The new version v5
+## The new version v6
 
-Based on habitatmap_stdized_2023_v1 and watersurfaces_v1.2
+Based on habitatmap_stdized_2023_v1 and watersurfaces_2024
 
 Checksums:
 

--- a/src/generate_watersurfaces_hab/index.Rmd
+++ b/src/generate_watersurfaces_hab/index.Rmd
@@ -50,7 +50,7 @@ library(leaflet)
 
 # ISO8601 timestamp to set as fixed value in the GeoPackage 
 # (to be UPDATED to the actual creation date; at least update for each version):
-Sys.setenv(OGR_CURRENT_DATE = "2024-12-11T00:00:00.000Z")
+Sys.setenv(OGR_CURRENT_DATE = "2025-01-08T00:00:00.000Z")
 # This is used to keep results reproducible, as the timestamp is otherwise
 # updated each time.
 # Above environment variable OGR_CURRENT_DATE is used by the GDAL driver.

--- a/src/generate_watersurfaces_hab/index.Rmd
+++ b/src/generate_watersurfaces_hab/index.Rmd
@@ -50,7 +50,7 @@ library(leaflet)
 
 # ISO8601 timestamp to set as fixed value in the GeoPackage 
 # (to be UPDATED to the actual creation date; at least update for each version):
-Sys.setenv(OGR_CURRENT_DATE = "2024-05-15T00:00:00.000Z")
+Sys.setenv(OGR_CURRENT_DATE = "2024-12-11T00:00:00.000Z")
 # This is used to keep results reproducible, as the timestamp is otherwise
 # updated each time.
 # Above environment variable OGR_CURRENT_DATE is used by the GDAL driver.

--- a/src/generate_watersurfaces_hab/renv.lock
+++ b/src/generate_watersurfaces_hab/renv.lock
@@ -1398,11 +1398,14 @@
     },
     "n2khab": {
       "Package": "n2khab",
-      "Version": "0.11.0",
-      "Source": "Repository",
-      "Repository": "https://inbo.r-universe.dev",
-      "RemoteUrl": "https://github.com/inbo/n2khab",
-      "RemoteSha": "74bce510ca746c4f32c8807ba70ed482200ab180",
+      "Version": "0.11.0.9000",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteRepo": "n2khab",
+      "RemoteUsername": "inbo",
+      "RemoteRef": "bd784a5",
+      "RemoteSha": "bd784a5a7ff51b4081611383aa40ca0f36602483",
       "Requirements": [
         "R",
         "assertthat",
@@ -1418,9 +1421,10 @@
         "rprojroot",
         "sf",
         "stringr",
-        "tidyr"
+        "tidyr",
+        "tidyselect"
       ],
-      "Hash": "b90c634da91affa0afe269ae9761d035"
+      "Hash": "4d4724da4ef1f90717fa8587c66dd3bf"
     },
     "nlme": {
       "Package": "nlme",

--- a/src/generate_watersurfaces_hab/renv.lock
+++ b/src/generate_watersurfaces_hab/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.3.2",
+    "Version": "4.4.2",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -19,31 +19,31 @@
   "Packages": {
     "DBI": {
       "Package": "DBI",
-      "Version": "1.2.2",
+      "Version": "1.2.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "164809cd72e1d5160b4cb3aa57f510fe"
+      "Hash": "065ae649b05f1ff66bb0c793107508f5"
     },
     "KernSmooth": {
       "Package": "KernSmooth",
-      "Version": "2.23-22",
+      "Version": "2.23-24",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "stats"
       ],
-      "Hash": "2fecebc3047322fa5930f74fae5de70f"
+      "Hash": "9f33a1ee37bbe8919eb2ec4b9f2473a5"
     },
     "MASS": {
       "Package": "MASS",
-      "Version": "7.3-60.0.1",
+      "Version": "7.3-61",
       "Source": "Repository",
-      "Repository": "RStudio",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "grDevices",
@@ -52,11 +52,11 @@
         "stats",
         "utils"
       ],
-      "Hash": "b765b28387acc8ec9e9c1530713cb19c"
+      "Hash": "0cafd6f0500e5deba33be22c46bf6055"
     },
     "Matrix": {
       "Package": "Matrix",
-      "Version": "1.6-5",
+      "Version": "1.7-1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -69,7 +69,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "8c7115cd3a0e048bda2a7cd110549f7a"
+      "Hash": "5122bb14d8736372411f955e1b16bc8a"
     },
     "R.methodsS3": {
       "Package": "R.methodsS3",
@@ -84,7 +84,7 @@
     },
     "R.oo": {
       "Package": "R.oo",
-      "Version": "1.26.0",
+      "Version": "1.27.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -93,7 +93,7 @@
         "methods",
         "utils"
       ],
-      "Hash": "4fed809e53ddb5407b3da3d0f572e591"
+      "Hash": "6ac79ff194202248cf946fe3a5d6d498"
     },
     "R.utils": {
       "Package": "R.utils",
@@ -132,24 +132,24 @@
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.0.12",
+      "Version": "1.0.13-1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "methods",
         "utils"
       ],
-      "Hash": "5ea2700d21e038ace58269ecdbeb9ec0"
+      "Hash": "6b868847b365672d6c1677b1608da9ed"
     },
     "askpass": {
       "Package": "askpass",
-      "Version": "1.2.0",
+      "Version": "1.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "sys"
       ],
-      "Hash": "cad6cf7f1d5f6e906700b9d3e718c796"
+      "Hash": "c39f4155b3ceb1a9a2799d700fbd4b6a"
     },
     "assertthat": {
       "Package": "assertthat",
@@ -163,13 +163,13 @@
     },
     "backports": {
       "Package": "backports",
-      "Version": "1.4.1",
+      "Version": "1.5.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "c39fbec8a30d23e721980b8afb31984c"
+      "Hash": "e1e1b9d75c37401117b636b7ae50827a"
     },
     "base64enc": {
       "Package": "base64enc",
@@ -183,17 +183,17 @@
     },
     "bit": {
       "Package": "bit",
-      "Version": "4.0.5",
+      "Version": "4.5.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "d242abec29412ce988848d0294b208fd"
+      "Hash": "5dc7b2677d65d0e874fc4aaf0e879987"
     },
     "bit64": {
       "Package": "bit64",
-      "Version": "4.0.5",
+      "Version": "4.5.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -203,7 +203,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "9fe98599ca456d6552421db0d6772d8f"
+      "Hash": "e84984bf5f12a18628d9a02322128dfd"
     },
     "blob": {
       "Package": "blob",
@@ -219,7 +219,7 @@
     },
     "bookdown": {
       "Package": "bookdown",
-      "Version": "0.39",
+      "Version": "0.41",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -232,7 +232,7 @@
         "xfun",
         "yaml"
       ],
-      "Hash": "cb4f7066855b6f936e8d25edc9a9cff9"
+      "Hash": "d8b74e267a5774ded5c91786d6d777bb"
     },
     "brew": {
       "Package": "brew",
@@ -253,14 +253,13 @@
     },
     "broom": {
       "Package": "broom",
-      "Version": "1.0.5",
+      "Version": "1.0.7",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "backports",
         "dplyr",
-        "ellipsis",
         "generics",
         "glue",
         "lifecycle",
@@ -270,11 +269,11 @@
         "tibble",
         "tidyr"
       ],
-      "Hash": "fd25391c3c4f6ecf0fa95f1e6d15378c"
+      "Hash": "8fcc818f3b9887aebaf206f141437cc9"
     },
     "bslib": {
       "Package": "bslib",
-      "Version": "0.7.0",
+      "Version": "0.8.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -292,18 +291,18 @@
         "rlang",
         "sass"
       ],
-      "Hash": "8644cc53f43828f19133548195d7e59e"
+      "Hash": "b299c6741ca9746fb227debcb0f9fb6c"
     },
     "cachem": {
       "Package": "cachem",
-      "Version": "1.0.8",
+      "Version": "1.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "fastmap",
         "rlang"
       ],
-      "Hash": "c35768291560ce302c0a6589f92e837d"
+      "Hash": "cd9a672193789068eb5a2aad65a0dedf"
     },
     "callr": {
       "Package": "callr",
@@ -361,14 +360,14 @@
     },
     "cli": {
       "Package": "cli",
-      "Version": "3.6.2",
+      "Version": "3.6.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "1216ac65ac55ec0058a6f75d7ca0fd52"
+      "Hash": "b21916dd77a27642b447374a5d30ecf3"
     },
     "clipr": {
       "Package": "clipr",
@@ -382,7 +381,7 @@
     },
     "colorspace": {
       "Package": "colorspace",
-      "Version": "2.1-0",
+      "Version": "2.1-1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -392,14 +391,14 @@
         "methods",
         "stats"
       ],
-      "Hash": "f20c47fd52fae58b4e377c37bb8c335b"
+      "Hash": "d954cb1c57e8d8b756165d7ba18aa55a"
     },
     "commonmark": {
       "Package": "commonmark",
-      "Version": "1.9.1",
+      "Version": "1.9.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "5d8225445acb167abf7797de48b2ee3c"
+      "Hash": "14eb0596f987c71535d07c3aff814742"
     },
     "conflicted": {
       "Package": "conflicted",
@@ -416,17 +415,17 @@
     },
     "cpp11": {
       "Package": "cpp11",
-      "Version": "0.4.7",
+      "Version": "0.5.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "5a295d7d963cc5035284dcdbaf334f4e"
+      "Hash": "91570bba75d0c9d3f1040c835cee8fba"
     },
     "crayon": {
       "Package": "crayon",
-      "Version": "1.5.2",
+      "Version": "1.5.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -434,11 +433,11 @@
         "methods",
         "utils"
       ],
-      "Hash": "e8a1e41acf02548751f45c718d55aa6a"
+      "Hash": "859d96e65ef198fd43e82b9628d593ef"
     },
     "credentials": {
       "Package": "credentials",
-      "Version": "2.0.1",
+      "Version": "2.0.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -448,7 +447,7 @@
         "openssl",
         "sys"
       ],
-      "Hash": "c7844b32098dcbd1c59cbd8dddb4ecc6"
+      "Hash": "09fd631e607a236f8cc7f9604db32cb8"
     },
     "crosstalk": {
       "Package": "crosstalk",
@@ -465,24 +464,24 @@
     },
     "curl": {
       "Package": "curl",
-      "Version": "5.2.1",
+      "Version": "6.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "411ca2c03b1ce5f548345d2fc2685f7a"
+      "Hash": "e8ba62486230951fcd2b881c5be23f96"
     },
     "data.table": {
       "Package": "data.table",
-      "Version": "1.15.4",
+      "Version": "1.16.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "8ee9ac56ef633d0c7cab8b2ca87d683e"
+      "Hash": "2e00b378fc3be69c865120d9f313039a"
     },
     "dbplyr": {
       "Package": "dbplyr",
@@ -576,18 +575,18 @@
     },
     "digest": {
       "Package": "digest",
-      "Version": "0.6.35",
+      "Version": "0.6.37",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "698ece7ba5a4fa4559e3d537e7ec3d31"
+      "Hash": "33698c4b3127fc9f506654607fb73676"
     },
     "downlit": {
       "Package": "downlit",
-      "Version": "0.4.3",
+      "Version": "0.4.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -603,7 +602,7 @@
         "withr",
         "yaml"
       ],
-      "Hash": "14fa1f248b60ed67e1f5418391a17b14"
+      "Hash": "45a6a596bf0108ee1ff16a040a2df897"
     },
     "dplyr": {
       "Package": "dplyr",
@@ -649,7 +648,7 @@
     },
     "e1071": {
       "Package": "e1071",
-      "Version": "1.7-14",
+      "Version": "1.7-16",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -661,7 +660,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "4ef372b716824753719a8a38b258442d"
+      "Hash": "27a09ca40266a1066d62ef5402dd51d6"
     },
     "ellipsis": {
       "Package": "ellipsis",
@@ -676,14 +675,13 @@
     },
     "evaluate": {
       "Package": "evaluate",
-      "Version": "0.23",
+      "Version": "1.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
-        "R",
-        "methods"
+        "R"
       ],
-      "Hash": "daf4a1246be12c1fa8c7705a0935c1a0"
+      "Hash": "3fd29944b231036ad67c3edb32e02201"
     },
     "fansi": {
       "Package": "fansi",
@@ -699,21 +697,21 @@
     },
     "farver": {
       "Package": "farver",
-      "Version": "2.1.1",
+      "Version": "2.1.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "8106d78941f34855c440ddb946b8f7a5"
+      "Hash": "680887028577f3fa2a81e410ed0d6e42"
     },
     "fastmap": {
       "Package": "fastmap",
-      "Version": "1.1.1",
+      "Version": "1.2.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "f7736a18de97dea803bde0a2daaafb27"
+      "Hash": "aa5e1cd11c2d15497494c5292d7ffcc8"
     },
     "fontawesome": {
       "Package": "fontawesome",
-      "Version": "0.5.2",
+      "Version": "0.5.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -721,7 +719,7 @@
         "htmltools",
         "rlang"
       ],
-      "Hash": "c2efdd5f0bcd1ea861c2d4e2a883a67d"
+      "Hash": "bd1297f9b5b1fc1372d19e2c4cd82215"
     },
     "forcats": {
       "Package": "forcats",
@@ -741,14 +739,14 @@
     },
     "fs": {
       "Package": "fs",
-      "Version": "1.6.4",
+      "Version": "1.6.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "15aeb8c27f5ea5161f9f6a641fafd93a"
+      "Hash": "7f48af39fa27711ea5fbd183b399920d"
     },
     "gargle": {
       "Package": "gargle",
@@ -785,7 +783,7 @@
     },
     "gert": {
       "Package": "gert",
-      "Version": "2.0.1",
+      "Version": "2.1.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -796,7 +794,7 @@
         "sys",
         "zip"
       ],
-      "Hash": "f70d3fe2d9e7654213a946963d1591eb"
+      "Hash": "ae855ad6d7be20dd7b05d43d25700398"
     },
     "ggplot2": {
       "Package": "ggplot2",
@@ -843,7 +841,7 @@
     },
     "git2r": {
       "Package": "git2r",
-      "Version": "0.33.0",
+      "Version": "0.35.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -851,11 +849,11 @@
         "graphics",
         "utils"
       ],
-      "Hash": "cdec9964efeda730d1b2cd3d5dd27747"
+      "Hash": "8828605664949b92d0bf3f931e7c431b"
     },
     "git2rdata": {
       "Package": "git2rdata",
-      "Version": "0.4.0",
+      "Version": "0.4.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -865,7 +863,7 @@
         "methods",
         "yaml"
       ],
-      "Hash": "873d32667639e500e05450cb54a36b55"
+      "Hash": "5ad03d40bdc00cc4a42ce88cc8b1a53e"
     },
     "gitcreds": {
       "Package": "gitcreds",
@@ -879,14 +877,14 @@
     },
     "glue": {
       "Package": "glue",
-      "Version": "1.7.0",
+      "Version": "1.8.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "e0b3a53876554bd45879e596cdb10a52"
+      "Hash": "5899f1eaa825580172bb56c08266f37c"
     },
     "googledrive": {
       "Package": "googledrive",
@@ -943,7 +941,7 @@
     },
     "gtable": {
       "Package": "gtable",
-      "Version": "0.3.5",
+      "Version": "0.3.6",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -952,9 +950,10 @@
         "glue",
         "grid",
         "lifecycle",
-        "rlang"
+        "rlang",
+        "stats"
       ],
-      "Hash": "e18861963cbc65a27736e02b3cd3c4a0"
+      "Hash": "de949855009e2d4d0e52a844e30617ae"
     },
     "haven": {
       "Package": "haven",
@@ -979,14 +978,14 @@
     },
     "highr": {
       "Package": "highr",
-      "Version": "0.10",
+      "Version": "0.11",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "xfun"
       ],
-      "Hash": "06230136b2d2b9ba5805e1963fa6e890"
+      "Hash": "d65ba49117ca223614f71b60d85b8ab7"
     },
     "hms": {
       "Package": "hms",
@@ -1065,7 +1064,7 @@
     },
     "httr2": {
       "Package": "httr2",
-      "Version": "1.0.1",
+      "Version": "1.0.7",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1082,7 +1081,7 @@
         "vctrs",
         "withr"
       ],
-      "Hash": "03d741c92fda96d98c3a3f22494e3b4a"
+      "Hash": "5a76da345ed4f3e6430517e08441edaf"
     },
     "ids": {
       "Package": "ids",
@@ -1125,13 +1124,13 @@
     },
     "jsonlite": {
       "Package": "jsonlite",
-      "Version": "1.8.8",
+      "Version": "1.8.9",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "methods"
       ],
-      "Hash": "e1b9c55281c5adc4dd113652d9e26768"
+      "Hash": "4e993b65c2c3ffbffce7bb3e2c6f832b"
     },
     "kableExtra": {
       "Package": "kableExtra",
@@ -1160,7 +1159,7 @@
     },
     "knitr": {
       "Package": "knitr",
-      "Version": "1.46",
+      "Version": "1.49",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1172,7 +1171,7 @@
         "xfun",
         "yaml"
       ],
-      "Hash": "6e008ab1d696a5283c79765fa7b56b47"
+      "Hash": "9fcb189926d93c636dea94fbe4f44480"
     },
     "labeling": {
       "Package": "labeling",
@@ -1187,14 +1186,14 @@
     },
     "later": {
       "Package": "later",
-      "Version": "1.3.2",
+      "Version": "1.4.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "Rcpp",
         "rlang"
       ],
-      "Hash": "a3e051d405326b8b0012377434c62b37"
+      "Hash": "501744395cac0bab0fbcfab9375ae92c"
     },
     "lattice": {
       "Package": "lattice",
@@ -1272,29 +1271,34 @@
     },
     "link2GI": {
       "Package": "link2GI",
-      "Version": "0.5-3",
+      "Version": "0.6-2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "R.utils",
+        "brew",
         "devtools",
         "methods",
+        "renv",
         "roxygen2",
+        "rstudioapi",
         "sf",
-        "stringr",
         "terra",
         "utils",
         "xfun",
-        "xml2"
+        "xml2",
+        "yaml"
       ],
-      "Hash": "4e2a21a038cbef3002c94c805d511749"
+      "Hash": "80734fa17d61ff5a157f29bd67f793cf"
     },
     "lubridate": {
       "Package": "lubridate",
       "Version": "1.9.3.9000",
       "Source": "Repository",
       "Repository": "https://inbo.r-universe.dev",
+      "RemoteUrl": "https://github.com/tidyverse/lubridate",
+      "RemoteSha": "e0b50c1759fe35e90a094c012e0c2ce60d47500d",
       "Requirements": [
         "R",
         "generics",
@@ -1394,9 +1398,11 @@
     },
     "n2khab": {
       "Package": "n2khab",
-      "Version": "0.10.1",
+      "Version": "0.11.0",
       "Source": "Repository",
       "Repository": "https://inbo.r-universe.dev",
+      "RemoteUrl": "https://github.com/inbo/n2khab",
+      "RemoteSha": "74bce510ca746c4f32c8807ba70ed482200ab180",
       "Requirements": [
         "R",
         "assertthat",
@@ -1414,13 +1420,13 @@
         "stringr",
         "tidyr"
       ],
-      "Hash": "0c77bc5e4608a9cdefffb054c6cd24c8"
+      "Hash": "b90c634da91affa0afe269ae9761d035"
     },
     "nlme": {
       "Package": "nlme",
-      "Version": "3.1-164",
+      "Version": "3.1-166",
       "Source": "Repository",
-      "Repository": "RStudio",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "graphics",
@@ -1428,17 +1434,17 @@
         "stats",
         "utils"
       ],
-      "Hash": "a623a2239e642806158bc4dc3f51565d"
+      "Hash": "ccbb8846be320b627e6aa2b4616a2ded"
     },
     "openssl": {
       "Package": "openssl",
-      "Version": "2.1.2",
+      "Version": "2.2.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "askpass"
       ],
-      "Hash": "ea2475b073243d9d338aa8f086ce973e"
+      "Hash": "d413e0fef796c9401a4419485f709ca1"
     },
     "pander": {
       "Package": "pander",
@@ -1477,7 +1483,7 @@
     },
     "pkgbuild": {
       "Package": "pkgbuild",
-      "Version": "1.4.4",
+      "Version": "1.4.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1488,7 +1494,7 @@
         "desc",
         "processx"
       ],
-      "Hash": "a29e8e134a460a01e0ca67a4763c595b"
+      "Hash": "30eaaab94db72652e72e3475c1b55278"
     },
     "pkgconfig": {
       "Package": "pkgconfig",
@@ -1502,7 +1508,7 @@
     },
     "pkgdown": {
       "Package": "pkgdown",
-      "Version": "2.0.9",
+      "Version": "2.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1513,11 +1519,11 @@
         "desc",
         "digest",
         "downlit",
+        "fontawesome",
         "fs",
-        "httr",
+        "httr2",
         "jsonlite",
-        "magrittr",
-        "memoise",
+        "openssl",
         "purrr",
         "ragg",
         "rlang",
@@ -1528,28 +1534,29 @@
         "xml2",
         "yaml"
       ],
-      "Hash": "8bf1151ed1a48328d71b937e651117a6"
+      "Hash": "df2912d5873422b55a13002510f02c9f"
     },
     "pkgload": {
       "Package": "pkgload",
-      "Version": "1.3.4",
+      "Version": "1.4.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "cli",
-        "crayon",
         "desc",
         "fs",
         "glue",
+        "lifecycle",
         "methods",
         "pkgbuild",
+        "processx",
         "rlang",
         "rprojroot",
         "utils",
         "withr"
       ],
-      "Hash": "876c618df5ae610be84356d5d7a5d124"
+      "Hash": "2ec30ffbeec83da57655b850cf2d3e0e"
     },
     "plyr": {
       "Package": "plyr",
@@ -1604,18 +1611,16 @@
     },
     "profvis": {
       "Package": "profvis",
-      "Version": "0.3.8",
+      "Version": "0.4.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "htmlwidgets",
-        "purrr",
         "rlang",
-        "stringr",
         "vctrs"
       ],
-      "Hash": "aa5a3864397ce6ae03458f98618395a1"
+      "Hash": "bffa126bf92987e677c12cfb5651fc1d"
     },
     "progress": {
       "Package": "progress",
@@ -1633,7 +1638,7 @@
     },
     "promises": {
       "Package": "promises",
-      "Version": "1.3.0",
+      "Version": "1.3.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1645,7 +1650,7 @@
         "rlang",
         "stats"
       ],
-      "Hash": "434cd5388a3979e74be5c219bcd6e77d"
+      "Hash": "c84fd4f75ea1f5434735e08b7f50fbca"
     },
     "proxy": {
       "Package": "proxy",
@@ -1661,14 +1666,14 @@
     },
     "ps": {
       "Package": "ps",
-      "Version": "1.7.6",
+      "Version": "1.8.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "dd2b9319ee0656c8acf45c7f40c59de7"
+      "Hash": "b4404b1de13758dea1c0484ad0d48563"
     },
     "purrr": {
       "Package": "purrr",
@@ -1687,14 +1692,14 @@
     },
     "ragg": {
       "Package": "ragg",
-      "Version": "1.3.0",
+      "Version": "1.3.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "systemfonts",
         "textshaping"
       ],
-      "Hash": "082e1a198e3329d571f4448ef0ede4bc"
+      "Hash": "0595fe5e47357111f29ad19101c7d271"
     },
     "rappdirs": {
       "Package": "rappdirs",
@@ -1708,7 +1713,7 @@
     },
     "raster": {
       "Package": "raster",
-      "Version": "3.6-26",
+      "Version": "3.6-30",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1718,7 +1723,7 @@
         "sp",
         "terra"
       ],
-      "Hash": "7d6eda494f34a644420ac1bfd2a8023a"
+      "Hash": "0e2829df8cb74a98179c886b023ffea8"
     },
     "rcmdcheck": {
       "Package": "rcmdcheck",
@@ -1813,17 +1818,17 @@
     },
     "renv": {
       "Package": "renv",
-      "Version": "1.0.7",
+      "Version": "1.0.11",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "utils"
       ],
-      "Hash": "397b7b2a265bc5a7a06852524dabae20"
+      "Hash": "47623f66b4e80b3b0587bc5d7b309888"
     },
     "reprex": {
       "Package": "reprex",
-      "Version": "2.1.0",
+      "Version": "2.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1841,22 +1846,22 @@
         "utils",
         "withr"
       ],
-      "Hash": "1425f91b4d5d9a8f25352c44a3d914ed"
+      "Hash": "97b1d5361a24d9fb588db7afe3e5bcbf"
     },
     "rlang": {
       "Package": "rlang",
-      "Version": "1.1.3",
+      "Version": "1.1.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "42548638fae05fd9a9b5f3f437fbbbe2"
+      "Hash": "3eec01f8b1dee337674b2e34ab1f9bc1"
     },
     "rmarkdown": {
       "Package": "rmarkdown",
-      "Version": "2.26",
+      "Version": "2.29",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1875,11 +1880,11 @@
         "xfun",
         "yaml"
       ],
-      "Hash": "9b148e7f95d33aac01f31282d49e4f44"
+      "Hash": "df99277f63d01c34e95e3d2f06a79736"
     },
     "roxygen2": {
       "Package": "roxygen2",
-      "Version": "7.3.1",
+      "Version": "7.3.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1901,7 +1906,7 @@
         "withr",
         "xml2"
       ],
-      "Hash": "c25fe7b2d8cba73d1b63c947bf7afdb9"
+      "Hash": "6ee25f9054a70f44d615300ed531ba8d"
     },
     "rprojroot": {
       "Package": "rprojroot",
@@ -1915,10 +1920,10 @@
     },
     "rstudioapi": {
       "Package": "rstudioapi",
-      "Version": "0.16.0",
+      "Version": "0.17.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "96710351d642b70e8f02ddeb237c46a7"
+      "Hash": "5f90cd73946d706cfe26024294236113"
     },
     "rversions": {
       "Package": "rversions",
@@ -1953,7 +1958,7 @@
     },
     "s2": {
       "Package": "s2",
-      "Version": "1.1.6",
+      "Version": "1.1.7",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1961,7 +1966,7 @@
         "Rcpp",
         "wk"
       ],
-      "Hash": "32f7b1a15bb01ae809022960abad5363"
+      "Hash": "3c8013cdd7f1d20de5762e3f97e5e274"
     },
     "sass": {
       "Package": "sass",
@@ -2025,7 +2030,7 @@
     },
     "sf": {
       "Package": "sf",
-      "Version": "1.0-16",
+      "Version": "1.0-19",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2044,11 +2049,11 @@
         "units",
         "utils"
       ],
-      "Hash": "ad57b543f7c3fca05213ba78ff63df9b"
+      "Hash": "fe02eec2f6b3ba0e24afe83d5ccfb528"
     },
     "shiny": {
       "Package": "shiny",
-      "Version": "1.8.1.1",
+      "Version": "1.9.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2077,7 +2082,7 @@
         "withr",
         "xtable"
       ],
-      "Hash": "54b26646816af9960a4c64d8ceec75d6"
+      "Hash": "6a293995a66e12c48d13aa1f957d09c7"
     },
     "sourcetools": {
       "Package": "sourcetools",
@@ -2108,7 +2113,7 @@
     },
     "stringi": {
       "Package": "stringi",
-      "Version": "1.8.3",
+      "Version": "1.8.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2117,7 +2122,7 @@
         "tools",
         "utils"
       ],
-      "Hash": "058aebddea264f4c99401515182e656a"
+      "Hash": "39e1144fd75428983dc3f63aa53dfa91"
     },
     "stringr": {
       "Package": "stringr",
@@ -2150,25 +2155,26 @@
     },
     "sys": {
       "Package": "sys",
-      "Version": "3.4.2",
+      "Version": "3.4.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "3a1be13d68d47a8cd0bfd74739ca1555"
+      "Hash": "de342ebfebdbf40477d0758d05426646"
     },
     "systemfonts": {
       "Package": "systemfonts",
-      "Version": "1.0.6",
+      "Version": "1.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
-        "cpp11"
+        "cpp11",
+        "lifecycle"
       ],
-      "Hash": "6d538cff441f0f1f36db2209ac7495ac"
+      "Hash": "213b6b8ed5afbf934843e6c3b090d418"
     },
     "terra": {
       "Package": "terra",
-      "Version": "1.7-71",
+      "Version": "1.7-83",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2176,7 +2182,7 @@
         "Rcpp",
         "methods"
       ],
-      "Hash": "e8611881ab70a4fb7a1f629b31e6fcff"
+      "Hash": "fbeffe988419d292225a57cf9c284802"
     },
     "testthat": {
       "Package": "testthat",
@@ -2209,15 +2215,16 @@
     },
     "textshaping": {
       "Package": "textshaping",
-      "Version": "0.3.7",
+      "Version": "0.4.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "cpp11",
+        "lifecycle",
         "systemfonts"
       ],
-      "Hash": "997aac9ad649e0ef3b97f96cddd5622b"
+      "Hash": "5142f8bc78ed3d819d26461b641627ce"
     },
     "tibble": {
       "Package": "tibble",
@@ -2330,13 +2337,13 @@
     },
     "tinytex": {
       "Package": "tinytex",
-      "Version": "0.50",
+      "Version": "0.54",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "xfun"
       ],
-      "Hash": "be7a76845222ad20adb761f462eed3ea"
+      "Hash": "3ec7e3ddcacc2d34a9046941222bf94d"
     },
     "tzdb": {
       "Package": "tzdb",
@@ -2376,7 +2383,7 @@
     },
     "usethis": {
       "Package": "usethis",
-      "Version": "2.2.3",
+      "Version": "3.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2398,12 +2405,13 @@
         "rprojroot",
         "rstudioapi",
         "stats",
+        "tools",
         "utils",
         "whisker",
         "withr",
         "yaml"
       ],
-      "Hash": "d524fd42c517035027f866064417d7e6"
+      "Hash": "0d7f5ca181f9b1e68b217bd93b6cc703"
     },
     "utf8": {
       "Package": "utf8",
@@ -2417,13 +2425,13 @@
     },
     "uuid": {
       "Package": "uuid",
-      "Version": "1.2-0",
+      "Version": "1.2-1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "303c19bfd970bece872f93a824e323d9"
+      "Hash": "34e965e62a41fcafb1ca60e9b142085b"
     },
     "vctrs": {
       "Package": "vctrs",
@@ -2477,21 +2485,18 @@
     },
     "waldo": {
       "Package": "waldo",
-      "Version": "0.5.2",
+      "Version": "0.6.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "cli",
         "diffobj",
-        "fansi",
         "glue",
         "methods",
-        "rematch2",
-        "rlang",
-        "tibble"
+        "rlang"
       ],
-      "Hash": "c7d3fd6d29ab077cbac8f0e2751449e6"
+      "Hash": "52f574062a7b66e56926988c3fbdb3b7"
     },
     "whisker": {
       "Package": "whisker",
@@ -2502,7 +2507,7 @@
     },
     "withr": {
       "Package": "withr",
-      "Version": "3.0.0",
+      "Version": "3.0.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2510,29 +2515,30 @@
         "grDevices",
         "graphics"
       ],
-      "Hash": "d31b6c62c10dcf11ec530ca6b0dd5d35"
+      "Hash": "cc2d62c76458d425210d1eb1478b30b4"
     },
     "wk": {
       "Package": "wk",
-      "Version": "0.9.1",
+      "Version": "0.9.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "5d4545e140e36476f35f20d0ca87963e"
+      "Hash": "37be35d733130f1de1ef51672cf7cdc0"
     },
     "xfun": {
       "Package": "xfun",
-      "Version": "0.43",
+      "Version": "0.49",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
+        "R",
         "grDevices",
         "stats",
         "tools"
       ],
-      "Hash": "ab6371d8653ce5f2f9290f4ec7b42a8e"
+      "Hash": "8687398773806cfff9401a2feca96298"
     },
     "xml2": {
       "Package": "xml2",
@@ -2572,10 +2578,10 @@
     },
     "yaml": {
       "Package": "yaml",
-      "Version": "2.3.8",
+      "Version": "2.3.10",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "29240487a071f535f5e5d5a323b7afbd"
+      "Hash": "51dab85c6c98e50a18d7551e9d49f76c"
     },
     "zip": {
       "Package": "zip",

--- a/src/generate_watersurfaces_hab/renv/activate.R
+++ b/src/generate_watersurfaces_hab/renv/activate.R
@@ -2,7 +2,7 @@
 local({
 
   # the requested version of renv
-  version <- "1.0.7"
+  version <- "1.0.11"
   attr(version, "sha") <- NULL
 
   # the project directory
@@ -98,6 +98,66 @@ local({
     unloadNamespace("renv")
 
   # load bootstrap tools   
+  ansify <- function(text) {
+    if (renv_ansify_enabled())
+      renv_ansify_enhanced(text)
+    else
+      renv_ansify_default(text)
+  }
+  
+  renv_ansify_enabled <- function() {
+  
+    override <- Sys.getenv("RENV_ANSIFY_ENABLED", unset = NA)
+    if (!is.na(override))
+      return(as.logical(override))
+  
+    pane <- Sys.getenv("RSTUDIO_CHILD_PROCESS_PANE", unset = NA)
+    if (identical(pane, "build"))
+      return(FALSE)
+  
+    testthat <- Sys.getenv("TESTTHAT", unset = "false")
+    if (tolower(testthat) %in% "true")
+      return(FALSE)
+  
+    iderun <- Sys.getenv("R_CLI_HAS_HYPERLINK_IDE_RUN", unset = "false")
+    if (tolower(iderun) %in% "false")
+      return(FALSE)
+  
+    TRUE
+  
+  }
+  
+  renv_ansify_default <- function(text) {
+    text
+  }
+  
+  renv_ansify_enhanced <- function(text) {
+  
+    # R help links
+    pattern <- "`\\?(renv::(?:[^`])+)`"
+    replacement <- "`\033]8;;ide:help:\\1\a?\\1\033]8;;\a`"
+    text <- gsub(pattern, replacement, text, perl = TRUE)
+  
+    # runnable code
+    pattern <- "`(renv::(?:[^`])+)`"
+    replacement <- "`\033]8;;ide:run:\\1\a\\1\033]8;;\a`"
+    text <- gsub(pattern, replacement, text, perl = TRUE)
+  
+    # return ansified text
+    text
+  
+  }
+  
+  renv_ansify_init <- function() {
+  
+    envir <- renv_envir_self()
+    if (renv_ansify_enabled())
+      assign("ansify", renv_ansify_enhanced, envir = envir)
+    else
+      assign("ansify", renv_ansify_default, envir = envir)
+  
+  }
+  
   `%||%` <- function(x, y) {
     if (is.null(x)) y else x
   }
@@ -142,7 +202,10 @@ local({
     # compute common indent
     indent <- regexpr("[^[:space:]]", lines)
     common <- min(setdiff(indent, -1L)) - leave
-    paste(substring(lines, common), collapse = "\n")
+    text <- paste(substring(lines, common), collapse = "\n")
+  
+    # substitute in ANSI links for executable renv code
+    ansify(text)
   
   }
   
@@ -305,8 +368,11 @@ local({
       quiet    = TRUE
     )
   
-    if ("headers" %in% names(formals(utils::download.file)))
-      args$headers <- renv_bootstrap_download_custom_headers(url)
+    if ("headers" %in% names(formals(utils::download.file))) {
+      headers <- renv_bootstrap_download_custom_headers(url)
+      if (length(headers) && is.character(headers))
+        args$headers <- headers
+    }
   
     do.call(utils::download.file, args)
   
@@ -385,10 +451,21 @@ local({
     for (type in types) {
       for (repos in renv_bootstrap_repos()) {
   
+        # build arguments for utils::available.packages() call
+        args <- list(type = type, repos = repos)
+  
+        # add custom headers if available -- note that
+        # utils::available.packages() will pass this to download.file()
+        if ("headers" %in% names(formals(utils::download.file))) {
+          headers <- renv_bootstrap_download_custom_headers(repos)
+          if (length(headers) && is.character(headers))
+            args$headers <- headers
+        }
+  
         # retrieve package database
         db <- tryCatch(
           as.data.frame(
-            utils::available.packages(type = type, repos = repos),
+            do.call(utils::available.packages, args),
             stringsAsFactors = FALSE
           ),
           error = identity
@@ -470,6 +547,14 @@ local({
   
   }
   
+  renv_bootstrap_github_token <- function() {
+    for (envvar in c("GITHUB_TOKEN", "GITHUB_PAT", "GH_TOKEN")) {
+      envval <- Sys.getenv(envvar, unset = NA)
+      if (!is.na(envval))
+        return(envval)
+    }
+  }
+  
   renv_bootstrap_download_github <- function(version) {
   
     enabled <- Sys.getenv("RENV_BOOTSTRAP_FROM_GITHUB", unset = "TRUE")
@@ -477,16 +562,16 @@ local({
       return(FALSE)
   
     # prepare download options
-    pat <- Sys.getenv("GITHUB_PAT")
-    if (nzchar(Sys.which("curl")) && nzchar(pat)) {
+    token <- renv_bootstrap_github_token()
+    if (nzchar(Sys.which("curl")) && nzchar(token)) {
       fmt <- "--location --fail --header \"Authorization: token %s\""
-      extra <- sprintf(fmt, pat)
+      extra <- sprintf(fmt, token)
       saved <- options("download.file.method", "download.file.extra")
       options(download.file.method = "curl", download.file.extra = extra)
       on.exit(do.call(base::options, saved), add = TRUE)
-    } else if (nzchar(Sys.which("wget")) && nzchar(pat)) {
+    } else if (nzchar(Sys.which("wget")) && nzchar(token)) {
       fmt <- "--header=\"Authorization: token %s\""
-      extra <- sprintf(fmt, pat)
+      extra <- sprintf(fmt, token)
       saved <- options("download.file.method", "download.file.extra")
       options(download.file.method = "wget", download.file.extra = extra)
       on.exit(do.call(base::options, saved), add = TRUE)

--- a/src/miscellaneous/watersurfaces.Rmd
+++ b/src/miscellaneous/watersurfaces.Rmd
@@ -29,10 +29,12 @@ opts_chunk$set(
 
 # Exploring the watersurfaces data source
 
-The previous versions were 1.0 (10.5281/zenodo.3386859) and 1.1 (10.5281/zenodo.4117543).
-We want to explore the changes in the most recent version: 1.2 (10.5281/zenodo.7440931).
+The previous versions were 1.0 (10.5281/zenodo.3386859), 1.1 (10.5281/zenodo.4117543)
+and 1.2 (10.5281/zenodo.7440931)
 
-```{r v1.2}
+We want to explore the changes in the most recent version: 2024 (10.5281/zenodo.14203168)
+
+```{r v2024}
 filepath <- file.path(fileman_up("n2khab_data"), "10_raw/watersurfaces/watersurfaces.gpkg")
 ```
 
@@ -56,7 +58,7 @@ Import the spatial layer:
 st_layers(filepath)
 ```
 
-```{r spatial-layer-v12}
+```{r spatial-layer-v2024}
 (ws <- read_sf(filepath, stringsAsFactors = TRUE, layer = "Watervlakken"))
 ```
 
@@ -72,7 +74,7 @@ This has been explored for version 1.1, and handled where needed by `n2khab::rea
 Given the factor levels explored below, it does not appear that more changes are needed.
 Hence this exploratory code has been dropped (2023-11-09).
 
-### A summary of the spatial layer for version 1.2
+### A summary of the spatial layer for version 2024
 
 ```{r}
 ws %>% 
@@ -80,30 +82,35 @@ ws %>%
   summary
 ```
 
-`PEILBEHEER` is a new column in version 1.2!
+`PEILBEHEER` was a new column in version 1.2 and is still present in version 2024.
+The column HYLAC was dropped in version 2024 (since the Hyla-codes are not used anymore by Natuurpunt)
 
-Let us look for a few typical errors more systematically in version 1.2.
+Let us look for a few typical errors more systematically in version 2024
 
 ### Are there `NA` values?
 
-There are plenty of `NA`'s but only in fields where we expect them.
+There are no `NA` values at all in version 2024 but ... see below! 
+
 
 ```{r}
 sapply(ws, function(x) sum(is.na(x)))
 ```
 
-We see a missing value in `KRWTYPES` for `KRWTYPE == "Ad"`, while all other `KRWTYPE` values are accompanied by a value for `KRWTYPES`.
+### Are there `""` values?
+
+Yes, plenty of them. 
+The empty fields are actually coded as an empty string ("")
+(or more accurately, since all those fields are factors: as a factor level  "") 
+
+The "" are in fields where `NA` can be expected.
 
 ```{r}
-ws |> 
-  st_drop_geometry() |> 
-  count(KRWTYPE, KRWTYPES)
+sapply(ws |> st_drop_geometry(), function(x) sum(as.character(x) == '', na.rm = TRUE))
 ```
-
 
 ### Are there `<Null>` values?
 
-One `<Null>` string is present in `GEBIED` column:
+None: 
 
 ```{r}
 sapply(ws |> st_drop_geometry(), function(x) sum(as.character(x) == '<Null>', na.rm = TRUE))
@@ -117,20 +124,21 @@ None:
 sapply(ws |> st_drop_geometry(), function(x) sum(as.character(x) == '0', na.rm = TRUE))
 ```
 
-Previously, `HYLAC` was zero if missing!
+### Are there any "/" values?
 
-Number of unique values of numeric variable `HYLAC`:
+None 
 
 ```{r}
-n_distinct(ws$HYLAC)
+sapply(ws |> st_drop_geometry(), function(x) sum(as.character(x) == "/", na.rm = TRUE))
 ```
 
-How many `NA` values for numeric variable `HYLAC`?
 
-Many! So the zeroes were replaced by `NA`.
+### Are there any "-" values?
+
+Yes there are "-" in `KRWTYPEA`, but it is expected (described in the metadata). 
 
 ```{r}
-ws$HYLAC %>% is.na %>% sum
+sapply(ws |> st_drop_geometry(), function(x) sum(as.character(x) == "-", na.rm = TRUE))
 ```
 
 ### Are WVLC codes unique?
@@ -145,15 +153,43 @@ ws$WVLC %>% unique %>% length == nrow(ws)
 ### Levels for each factor
 
 We can compare the levels for each factor variable with the information given in 
-[Scheers et al. (2022)](https://pureportal.inbo.be/nl/publications/watervlakken-versie-12-polygonenkaart-van-stilstaand-water-in-vla).
+[Leyssen et al. (2024)](https://pureportal.inbo.be/nl/publications/watervlakken-2024-polygonenkaart-van-stilstaand-water-in-vlaander).
 
 We do not check `NAAM` and `GEBIED` since there are many possible options.
+
+**WVLC** 
+
+Similar problem for the `WVLC` but we can check whether the structure of the codes is correct:
+
+Does `WVLC`  start with a province code?
+
+```{r}
+substr(levels(ws$WVLC),1 ,3) %>% unique()
+```
+
+How many records with an unexpected length? (not 10 characters)?
+
+```{r}
+ws %>% filter(str_length(WVLC) != 10) %>% nrow()
+```
+
+There is one problem: 
+
+```{r}
+ws |> filter(str_detect(WVLC, pattern = "d")) |> as.matrix() |> t()
+```
 
 **KRWTYPE**: the codes are correct but there are more codes mentioned in the metadata report.
 
 ```{r}
 levels(ws$KRWTYPE)
 ```
+**KRWTYPEA**: the codes are correct but there are more codes mentioned in the metadata report.
+
+```{r}
+levels(ws$KRWTYPEA)
+```
+
 
 **KRWTYPES** (status): the codes in the spatial layer are the same as in the metadata report.
 
@@ -161,7 +197,32 @@ levels(ws$KRWTYPE)
 levels(ws$KRWTYPES)
 ```
 
-**DIEPKL**: there are extra codes in the dataset ("0 - 2 m", "2 - 4 m", "4 - 6 m" and "> 6 m") and the ordering of the levels could be more logical.
+`KRWTYPE` / `KRWTYPEA` / `KRWTYPES` consistency:
+
+```{r}
+ws |> 
+  st_drop_geometry() |> 
+  count(KRWTYPE, KRWTYPES) |> 
+  print()
+```
+
+```{r}
+ws |> 
+  st_drop_geometry() |> 
+  filter(!is.na(KRWTYPEA), KRWTYPEA != "-") |> 
+  count(KRWTYPE, KRWTYPEA) |> 
+  print(n = Inf)
+```
+
+One record has `KRWTYPES` set to ‘voorlopig’:
+
+```{r}
+ws |> filter(KRWTYPES == "voorlopig") |> as.matrix() |> t()
+```
+
+After discussion with the authors, this seems to be correct.
+
+**DIEPKL**: the codes in the spatial layer are the same as in the metadata report but the ordering of the levels could be more logical.
 
 ```{r}
 levels(ws$DIEPKL)
@@ -174,37 +235,29 @@ However this was just for exploratory purposes as it was not the purpose to alwa
 - also in the future we will not rectify this (by default) in reading functions for raw data sources: problems in the data will be returned as-is and should be solved in a future version of the data source.
 By default we just streamline column names and variable types, we make sure that values referring to `NA` are effectively returned as `NA` and we try to avoid some encoding problems.
 
-Because on Windows the ≥/\u2265 character is not well displayed, we will recode it into '=>'
-(otherwise "≥" in ws$DIEPKL are rendered as "=" in the html output):
+Because on Windows the ≥/\u2265 character is not well displayed, we had to recode it into '=>'
+(otherwise "≥" in ws$DIEPKL was rendered as "=" in the html output). 
+Note that this is not needed anymore for version 2024 that does not contain the character ≥ anymore 
+but we will keep this in the read fucntion for the previous versions
 
 ```{r}
 levels(ws$DIEPKL) <- gsub(pattern = "\u2265", ">=", levels(ws$DIEPKL))
 levels(ws$DIEPKL)
 ```
 
-**CONNECT**: the codes differ from those in the report, which have the codes from version 1.1.
+**CONNECT**: the codes in the spatial layer are the same as in the metadata report.
 
 ```{r}
 levels(ws$CONNECT)
 ```
 
-These are the categories in the metadata report for `CONNECT`:
-
-- geïsoleerd: niet verbonden met een waterloop 
-- permanent: het watervlak staat permanent in verbinding met minstens één
-waterloop 
-- periodiek: het watervlak staat tijdelijk (door peilbeheer of droogte) in verbinding
-met minstens één waterloop
-
-**FUNCTIE**: the code "veedrenk" is not mentioned in the metadata report and 
-there are many more codes in the report than in the 
-dataset
+**FUNCTIE**: there are many more codes in the report than in the dataset
 
 ```{r}
 levels(ws$FUNCTIE)
 ```
 
-And here are the categories in the metadata report for `FUNCTIE`:
+Here are the categories in the metadata report for `FUNCTIE`:
 
 functie                       toewijzing
 ----------------------        ---------------------
@@ -212,19 +265,19 @@ natuur                        doelstelling natuurbehoud
 hengelintensief               intensief hengelen (met infrastructuur, bepoting of gebruikt voor wedstrijdhengelen)
 hengelextensief               extensief hengelen (geen infrastructuur, bepoting of wedstrijdhengelen)
 jacht                         jagen
-tuin/park                     esthetisch (verblijfsrecreatie, tuin- en parkvijvers)
+tuin_park                     esthetisch (verblijfsrecreatie, tuin- en parkvijvers)
 vogel                         waterpartij voor gedomesticeerde watervogels
 viskweek                      opkweken van vis
 zwemmen                       zwemmen
-duiken                        duiken
-zachterecreatie               niet gemotoriseerde watersport
-motorrecreatie                gemotoriseerde watersport
-berging                       waterberging ten behoeve van overstromings- of peilbeheer
+duik                          duiken
+zachteRecreatie               niet gemotoriseerde waterrecreatie
+motorrecreatie                gemotoriseerde waterrecreatie
+waterberging                  waterberging ten behoeve van overstromings- of peilbeheer
 opslag                        reservoir voor water (industrie, landbouw, bluswater, waterkracht…)
 drinkwater                    drinkwaterwinning
 zuivering                     (kleinschalige) waterzuivering, infiltratie
 bezinking                     bezinking van proceswater
-drinkplaats                   watervoorziening voor vee
+veedrenk                      watervoorziening voor vee
 geen                          geen specifieke functie
 
 **PEILBEHEER**: one code less than in the report.
@@ -233,16 +286,14 @@ geen                          geen specifieke functie
 levels(ws$PEILBEHEER)
 ```
 
+
 ## Potential issues
 
-- `KRWTYPE`, `FUNCTIE`, `PEILBEHEER`: more levels in the metadata report than in the dataset.
+- there is a new field: `KRWTYPEA` and one field was dropped `HYLAC`
+- `KRWTYPE`, `KRWTYPEA`, `FUNCTIE`, `PEILBEHEER`: more levels in the metadata report than in the dataset.
 This is not necessarily a problem.
-- `DIEPKL`, `FUNCTIE`: extra codes in the dataset that are not present in the report
-- `CONNECT`: codes differ between dataset and report
-- a missing value in `KRWTYPES` for `KRWTYPE == "Ad"`
-- One `<Null>` string is present in `GEBIED` column
-
-The extra codes will be discussed with the authors of the layers.
+- All the missing values for the factors are coded as level empty string ""  
+- One wrong WVLC code ("d") in de Kleiputten van Heist (Palingpot)
 
 
 ## Validity of the geometries
@@ -250,8 +301,9 @@ The extra codes will be discussed with the authors of the layers.
 Let's inspect features with invalid or corrupt geometry:
 
 ```{r}
-st_is_valid(ws) %>% table
-invalid_geoms <- ws[!st_is_valid(ws) | is.na(st_is_valid(ws)), ]
+validities <- st_is_valid(ws)
+validities %>% table
+invalid_geoms <- ws[!validities | is.na(validities), ]
 st_is_valid(invalid_geoms, reason = TRUE)
 ```
 
@@ -275,7 +327,7 @@ all(st_is_valid(valid_geoms))
 ```
 
 So this works well; in derived data we will fix these geometries.
-We might also consider an optional geometry reparation step in `read_watersurfaces()`.
+We can use the optional geometry reparation step in `read_watersurfaces()`.
 
 We also check that no empty geometries are present:
 
@@ -290,7 +342,7 @@ Refer to <https://github.com/inbo/n2khab-preprocessing/issues/60> and <https://r
 
 ```{r plot}
 
-# plot watersurfaces v1.2
+# plot watersurfaces v2024
  p <- ggplot() +
   geom_sf(data = ws, aes(), color = "blue")
 
@@ -304,24 +356,25 @@ print(p)
 
 ```
 
-<!-- ### Are all the watersurfaces in Flanders? -->
+<!-- ### Are all the watersurfaces in Flanders?  -->
 
 <!-- ```{r streams-in-fl} -->
 <!-- in_vl <- st_contains(x = sf_vl, y = ws) -->
 
-<!-- not_contained <- ws %>%  -->
-<!--   st_drop_geometry() %>%  -->
-<!--   mutate(orig_rowname = rownames(.)) %>%  -->
+<!-- not_contained <- ws %>% -->
+<!--   st_drop_geometry() %>% -->
+<!--   mutate(orig_rowname = rownames(.)) %>% -->
 <!--   filter(!rownames(.) %in% in_vl[[1]]) -->
 
-<!-- # 61 watersurfaces -->
+<!-- # 62 watersurfaces -->
 <!-- print(not_contained %>% nrow()) -->
 
-<!-- not_contained %>%  -->
-<!--   distinct(WVLC, NAAM) %>%  -->
+<!-- not_contained %>% -->
+<!--   distinct(WVLC, NAAM) %>% -->
 <!--   kable() -->
 <!-- ``` -->
-<!-- 61 watersurfaces are not 'contained' within the polygon for Flanders (see list above) -->
+
+<!-- 62 watersurfaces are not 'contained' within the polygon for Flanders (see list above) -->
 
 # Tidyverse-styled, internationalized column names when using the data source in R
 
@@ -333,10 +386,10 @@ data source variable          data frame variable
 ----------------------        ---------------------
 `WVLC`                        `polygon_id` 
 `WTRLICHC`                    `wfd_code`
-`HYLAC`                       `hyla_code`
 `NAAM`                        `name`
 `GEBIED`                      `area_name`
 `KRWTYPE`                     `wfd_type `
+`KRWTYPEA`                    `wfd_type_alternative`
 `KRWTYPES`                    `wfd_type_certain`
 `DIEPKL`                      `depth_class`
 `CONNECT`                     `connectivity`
@@ -347,12 +400,14 @@ data source variable          data frame variable
 
 - not uptaking `OPPWVL`, `OMTWVL`, `SHAPE_Length`, `SHAPE_Area` (area & perimeter are easily calculated etc) -- OK
 - sort by `polygon_id` -- OK
-- add translations to long text for `wfd_type ` and `connectivity`  -- OK but not by default
+- add translations to long text for `wfd_type `, `wfd_type_alternative `, `connectivity`  -- OK but not by default
 - add translations to long text for  `usage`? -- for a later version (as more 
 codes will be used)
-- converting null / 0 values to `NA` -- OK
-- support new variable `water_level_management` -- OK
-
+- converting null / 0 / "" values to `NA` -- OK
+- support variable water_level_management (since 1.2) – OK
+- support variable wfd_type_alternative (since v2024) – OK
+- made variable hyla_code optional (dropped in v2024) – OK
+- there is one wrong WVLC code ("d") in de Kleiputten van Heist (Palingpot) - should we stay true to source?
 
 # Used environment
 

--- a/src/miscellaneous/watersurfaces.Rmd
+++ b/src/miscellaneous/watersurfaces.Rmd
@@ -406,8 +406,8 @@ codes will be used)
 - converting null / 0 / "" values to `NA` -- OK
 - support variable water_level_management (since 1.2) – OK
 - support variable wfd_type_alternative (since v2024) – OK
-- made variable hyla_code optional (dropped in v2024) – OK
-- there is one wrong WVLC code ("d") in de Kleiputten van Heist (Palingpot) - should we stay true to source?
+- make variable hyla_code optional (dropped in v2024) – OK
+- there is one wrong WVLC code ("d" should be "WVLKNO0072") in de Kleiputten van Heist (Palingpot) - should we stay true to source?  see <https://github.com/inbo/n2khab/pull/192>
 
 # Used environment
 


### PR DESCRIPTION
I updated the checks for version 2024 of watersurfaces : miscellaneous/watersurfaces.Rmd
[watersurfaces.zip](https://github.com/user-attachments/files/18345612/watersurfaces.zip)

And I updated the code to generate v6 of watersufaces_hab (based on watersurfaces_2024)
[generating_watersurfaces_hab.zip](https://github.com/user-attachments/files/18345618/generating_watersurfaces_hab.zip)
The new file is on our INBO Drive (MNM > 130 Methodologie > Dataketen - methodologie)